### PR TITLE
Add location priority

### DIFF
--- a/R/location.R
+++ b/R/location.R
@@ -319,6 +319,15 @@ location_resolve_valid <- function(location, root, include_local) {
     location <- setdiff(location, local)
   }
 
+  ## We could throw nicer errors here if we included this check (and
+  ## the setdiff) in every one of the above the three branches above,
+  ## but that makes things pretty hard to follow. We'll do some work
+  ## on nicer errors later once we get this ready for people to
+  ## actually use.
+  if (length(location) == 0) {
+    stop("No suitable location found")
+  }
+
   location
 }
 

--- a/R/location.R
+++ b/R/location.R
@@ -178,7 +178,7 @@ outpack_location_pull_packet <- function(id, location = NULL, recursive = FALSE,
     return(id)
   }
 
-  plan <- location_pull_plan(id, location, root)
+  plan <- location_build_pull_plan(id, location, root)
 
   ## At this point we should really be providing logging about how
   ## many packets, files, etc are being copied.  I've done this as a
@@ -323,7 +323,7 @@ location_resolve_valid <- function(location, root, include_local) {
 }
 
 
-location_pull_plan <- function(id, location, root) {
+location_build_pull_plan <- function(id, location, root) {
   ## For each packet we'll use the location with the highest priority
   ## based on the list of locations
   location <- location_resolve_valid(location, root, include_local = FALSE)

--- a/R/root.R
+++ b/R/root.R
@@ -152,7 +152,8 @@ read_locations <- function(root, prev) {
   }
   new <- do.call(rbind, lapply(locations, read_location, root$path, prev))
   ret <- rbind(prev, new)
-  ret <- ret[order(ret$location), ]
+  ## Always sort by location (highest priority first) then id
+  ret <- ret[order(match(ret$location, locations), ret$packet), ]
   ## Avoids weird computed rownames - always uses 1:n
   rownames(ret) <- NULL
   ret

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -14,6 +14,14 @@ assert_character <- function(x, name = deparse(substitute(x))) {
 }
 
 
+assert_numeric <- function(x, name = deparse(substitute(x))) {
+  if (!is.numeric(x)) {
+    stop(sprintf("'%s' must be numeric", name), call. = FALSE)
+  }
+  invisible(x)
+}
+
+
 assert_logical <- function(x, name = deparse(substitute(x))) {
   if (!is.logical(x)) {
     stop(sprintf("'%s' must be logical", name), call. = FALSE)
@@ -25,6 +33,12 @@ assert_logical <- function(x, name = deparse(substitute(x))) {
 assert_scalar_character <- function(x, name = deparse(substitute(x))) {
   assert_scalar(x, name)
   assert_character(x, name)
+}
+
+
+assert_scalar_numeric <- function(x, name = deparse(substitute(x))) {
+  assert_scalar(x, name)
+  assert_numeric(x, name)
 }
 
 

--- a/inst/schema/config.json
+++ b/inst/schema/config.json
@@ -40,11 +40,14 @@
                     "type": {
                         "const": "path"
                     },
+                    "priority": {
+                        "type": "number"
+                    },
                     "path": {
                         "type": "string"
                     }
                 },
-                "required": ["name", "type", "path"]
+                "required": ["name", "type", "path", "priority"]
             }
         }
     },

--- a/man/outpack_location_add.Rd
+++ b/man/outpack_location_add.Rd
@@ -4,7 +4,7 @@
 \alias{outpack_location_add}
 \title{Add a new location}
 \usage{
-outpack_location_add(name, path, root = NULL)
+outpack_location_add(name, path, priority = 0, root = NULL)
 }
 \arguments{
 \item{name}{The short name of the location to use.  Cannot be in
@@ -12,6 +12,14 @@ use, and cannot be one of \code{local} or \code{orphan}}
 
 \item{path}{The path to the directory containing another outpack
 archive.}
+
+\item{priority}{The priority of the location. This is used when
+deciding where to pull packets from
+(\link{outpack_location_pull_packet}), and will be used in
+the query interface. A priority of 0 corresponds to the same
+priority as local packets, while larger numbers have higher
+priority and negative numbers have lower priority.  Ties will be
+resolved in an arbitrary order.}
 
 \item{root}{The outpack root. Will be searched for from the
 current directory if not given.}

--- a/man/outpack_location_pull_packet.Rd
+++ b/man/outpack_location_pull_packet.Rd
@@ -4,13 +4,22 @@
 \alias{outpack_location_pull_packet}
 \title{Pull a single packet from a location}
 \usage{
-outpack_location_pull_packet(id, location, recursive = FALSE, root = NULL)
+outpack_location_pull_packet(
+  id,
+  location = NULL,
+  recursive = FALSE,
+  root = NULL
+)
 }
 \arguments{
 \item{id}{The id of the packet(s) to pull}
 
-\item{location}{The name of the location to pull from.  Later we
-will relax this (see mrc-3030)}
+\item{location}{Control the location that the packet can be pulled
+from.  The default (\code{NULL}) will try and pull the packet from
+anywhere it can be found, starting with locations that have the
+highest priority.  Provide a string to limit the search to a
+particular location, or provide a number to limit to locations
+with at least this priority.}
 
 \item{recursive}{Logical, indicating if we should recursively pull
 all packets that are referenced by the packets specified in

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -528,35 +528,35 @@ test_that("Can filter locations", {
   ids <- unique(c(ids_a, ids_b, ids_c, ids_d))
 
   expect_equal(
-    location_pull_plan(ids, NULL, root = root$dst),
+    location_build_pull_plan(ids, NULL, root = root$dst),
     data_frame(
       packet = ids,
       location = c("a", "a", "a", "b", "b", "b", "c", "c", "c", "d", "d", "d")))
   ## Invert priority order:
   expect_equal(
-    location_pull_plan(ids, c("d", "c", "b", "a"), root = root$dst),
+    location_build_pull_plan(ids, c("d", "c", "b", "a"), root = root$dst),
     data_frame(
       packet = ids,
       location = c("d", "d", "d", "b", "b", "b", "d", "d", "d", "d", "d", "d")))
   ## Drop redundant locations
   expect_equal(
-    location_pull_plan(ids, c("b", "d"), root = root$dst),
+    location_build_pull_plan(ids, c("b", "d"), root = root$dst),
     data_frame(
       packet = ids,
       location = c("b", "b", "b", "b", "b", "b", "d", "d", "d", "d", "d", "d")))
   ## Some corner cases:
   expect_equal(
-    location_pull_plan(ids_a[[1]], NULL, root = root$dst),
+    location_build_pull_plan(ids_a[[1]], NULL, root = root$dst),
     data_frame(packet = ids_a[[1]], location = "a"))
   expect_equal(
-    location_pull_plan(character(), NULL, root = root$dst),
+    location_build_pull_plan(character(), NULL, root = root$dst),
     data_frame(packet = character(), location = character()))
 
   ## Failure to find things:
   err <- expect_error(
-    location_pull_plan(ids, c("a", "b", "c"), root = root$dst),
+    location_build_pull_plan(ids, c("a", "b", "c"), root = root$dst),
     "Failed to find packets at location 'a', 'b', 'c'")
   expect_error(
-    location_pull_plan(ids, 10, root = root$dst),
+    location_build_pull_plan(ids, 10, root = root$dst),
     err$message, fixed = TRUE)
 })

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -250,7 +250,7 @@ test_that("can pull a packet from one location to another, using file store", {
   id <- create_random_packet(root$src)
   outpack_location_add("src", root$src$path, root = root$dst)
   outpack_location_pull_metadata(root = root$dst)
-  outpack_location_pull_packet(id, "src", root = root$dst)
+  outpack_location_pull_packet(id, root = root$dst)
 
   index <- root$dst$index()
   expect_equal(index$unpacked$packet, id)

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -493,6 +493,19 @@ test_that("Can resolve locations", {
 })
 
 
+test_that("informative error message when no locations configured", {
+  path <- tempfile()
+  on.exit(unlink(path, recursive = TRUE))
+  root <- outpack_init(path)
+  expect_error(
+    location_resolve_valid(NULL, root, FALSE),
+    "No suitable location found")
+  expect_error(
+    outpack_location_pull_packet(outpack_id(), root = root),
+    "No suitable location found")
+})
+
+
 ## The test setup here is hard to do because we don't yet support
 ## having location_path filtering metadata to the packets that it can
 ## actually provide.

--- a/tests/testthat/test-util-assert.R
+++ b/tests/testthat/test-util-assert.R
@@ -12,6 +12,13 @@ test_that("assert_character", {
 })
 
 
+test_that("assert_numeric", {
+  expect_silent(assert_numeric(1))
+  expect_error(assert_numeric("one"), "must be numeric")
+  expect_error(assert_numeric(TRUE), "must be numeric")
+})
+
+
 test_that("assert_logical", {
   expect_silent(assert_logical(TRUE))
   expect_error(assert_logical(1), "must be logical")
@@ -30,6 +37,17 @@ test_that("assert_named", {
 test_that("assert_is", {
   expect_error(assert_is("x", "foo"), "must be a foo")
   expect_silent(assert_is(structure("x", class = "foo"), "foo"))
+})
+
+
+test_that("assert_scalar_numeric", {
+  expect_silent(assert_scalar_numeric(1))
+  expect_error(assert_scalar_numeric(numeric(0)),
+               "must be a scalar")
+  expect_error(assert_scalar_numeric(c(1, 2)),
+               "must be a scalar")
+  expect_error(assert_scalar_numeric("one"),
+               "must be numeric")
 })
 
 


### PR DESCRIPTION
This PR adds support for the idea of location priority (or "trust" as I've called it in the ticket).

The idea here generalises a bit orderly's concept of letting dependencies from drafts override "more trustable" dependencies from the archive (which have probably come from some remote). Here we allow any location to have a priority and we will use that in a number of places. Here the thing I needed was to remove the "location" argument to `outpack_location_pull_packet` as it should not matter where we pull from.

This is part of a yak that I'm shaving - we need this in order to be able to automatically pull in missing packets which we'd need to be able to make sure that a location has all packets, which we need to have some policy on locations that they promise to be able to ship anything!

Issues for later:

* Can't easily view the current priorities of locations
* Can't edit the priority of a location
