### PR TITLE
Use a unique id for locations

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -96,7 +96,9 @@ config_new <- function(path_archive, use_file_store, require_complete_tree) {
       use_file_store = use_file_store,
       require_complete_tree = require_complete_tree,
       hash_algorithm = hash_algorithm),
-    location = list())
+    location = list(list(
+      name = local, id = location_id(), priority = 0,
+      type = "local")))
 }
 
 
@@ -116,6 +118,11 @@ config_write <- function(config, root_path) {
 
 config_read <- function(root_path) {
   config <- jsonlite::read_json(file.path(root_path, ".outpack/config.json"))
-  names(config$location) <- vcapply(config$location, "[[", "name")
+  config$location <- data_frame(
+    name = vcapply(config$location, "[[", "name"),
+    id = vcapply(config$location, "[[", "id"),
+    priority = vnapply(config$location, "[[", "priority"),
+    type = vcapply(config$location, "[[", "type"),
+    args = I(lapply(config$location, "[[", "args")))
   config
 }

--- a/R/location.R
+++ b/R/location.R
@@ -207,13 +207,10 @@ outpack_location_pull_packet <- function(id, location = NULL, recursive = NULL,
 
 location_driver <- function(location_id, root) {
   i <- match(location_id, root$config$location$id)
-  if (is.na(i)) {
-    stop(sprintf("Unknown location '%s'", location_id))
-  }
   ## Once we support multiple location types, we'll need to consider
   ## this more carefully; leaving an assertion in to make it more
   ## obvious where change is needed.
-  stopifnot(root$config$location$type[[i]] == "path")
+  stopifnot(!is.na(i), root$config$location$type[[i]] == "path")
   path <- root$config$location$args[[i]]$path
   outpack_location_path$new(path)
 }

--- a/R/location.R
+++ b/R/location.R
@@ -50,7 +50,8 @@ outpack_location_add <- function(name, path, priority = 0, root = NULL) {
 
   config <- root$config
 
-  loc <- list(name = name, type = "path", path = path, priority = priority)
+  loc <- list(name = name, id = location_id(), priority = priority,
+              type = "path", args = list(path = path))
   config$location <- c(unname(config$location), list(loc))
   config_write(config, root$path)
 
@@ -75,27 +76,13 @@ outpack_location_add <- function(name, path, priority = 0, root = NULL) {
 ##'
 ##' @export
 outpack_location_list <- function(root = NULL) {
-  names(outpack_location_priority(root))
+  outpack_root_locate(root)$location$name
 }
 
 
-## TODO: similar to `git remote -v` we might support an extended mode
-## here (returning a data.frame) or a second function that returns
-## richer information about the locations.  This function is going to
-## be called fairly frequently so the cheap version here and above is
-## important.
-##
-## Probably something like this needs exporting, but holding off for now:
-## * would be simplified if we kept something for local in the main
-##   set of locations
-## * probably want a function that returns a data.frame of location
-##   information - could construct this when we load the config I suspect?
-## * we'll want to report information about where the location points at
-##   and that will be easiest once we have more than one type.
 outpack_location_priority <- function(root = NULL) {
   root <- outpack_root_locate(root)
-  priority <- c(local = 0, vnapply(root$config$location, "[[", "priority"))
-  priority[order(priority, decreasing = TRUE)]
+  set_names(root$config$location$priority, root$config$location$name)
 }
 
 
@@ -381,4 +368,9 @@ location_build_pull_plan <- function(id, location, root) {
   }
 
   plan
+}
+
+
+location_id <- function() {
+  paste(as.character(openssl::rand_bytes(4)), collapse = "")
 }

--- a/R/schema.R
+++ b/R/schema.R
@@ -1,5 +1,5 @@
 outpack_schema_version <- function() {
-  if (is.null(cache$schema)) {
+  if (is.null(cache$schema_version)) {
     path <- outpack_file("schema/metadata.json")
     cache$schema_version <- jsonlite::read_json(path)$version
   }

--- a/inst/schema/config.json
+++ b/inst/schema/config.json
@@ -37,17 +37,17 @@
                     "name": {
                         "type": "string"
                     },
-                    "type": {
-                        "const": "path"
+                    "id": {
+                        "$ref": "locationId.json"
                     },
                     "priority": {
                         "type": "number"
                     },
-                    "path": {
-                        "type": "string"
+                    "type": {
+                        "enum": ["local", "path"]
                     }
                 },
-                "required": ["name", "type", "path", "priority"]
+                "required": ["name", "id", "priority", "type"]
             }
         }
     },

--- a/inst/schema/locationId.json
+++ b/inst/schema/locationId.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Location id, globally unique",
+    "type": "string",
+    "pattern": "^[0-9a-f]{8}$"
+}

--- a/inst/schema/unpacked.json
+++ b/inst/schema/unpacked.json
@@ -22,8 +22,9 @@
         },
 
         "location": {
-            "description": "The name of the location that the packet was pulled from"
+            "description": "The id of the location that the packet was pulled from",
+            "$ref": "locationId.json"
         }
     },
-    "required": ["schemaVersion", "packet", "time"]
+    "required": ["schemaVersion", "packet", "time", "location"]
 }

--- a/tests/testthat/test-packet.R
+++ b/tests/testthat/test-packet.R
@@ -40,7 +40,9 @@ test_that("Can run a basic packet", {
   expect_true(file.exists(path_metadata))
   outpack_schema("metadata")$validate(path_metadata)
 
-  path_location <- file.path(path, ".outpack", "location", "local", id)
+  location_id <- root$config$location$id
+
+  path_location <- file.path(path, ".outpack", "location", location_id, id)
   expect_true(file.exists(path_location))
   outpack_schema("location")$validate(path_location)
 
@@ -79,7 +81,7 @@ test_that("Can run a basic packet", {
 
   expect_setequal(names(index$unpacked), c("packet", "time", "location"))
   expect_equal(index$unpacked$packet, id)
-  expect_equal(index$unpacked$location, "local")
+  expect_equal(index$unpacked$location, location_id)
   expect_s3_class(index$unpacked$time, "POSIXt")
 
   ## Easily retrieve metadata from root:


### PR DESCRIPTION
A bit of a fiddly one, with no user-facing changes (though we have no users yet of course).

This PR changes the location primary key from the name to some generated id (here, a random 4-byte hex string). There are a couple of advantages of this (none of which are implemented here):

* we can safely cache location drivers, which will make it easy to cache credentials when using http-based remotes (this was a headache in orderly) - easy because the id will be unique across any number of roots so we can use a single package cache.
* easier to rename locations if needed because no data is stored against the name, just the id (with the name being a tag against an id)

The other reason for doing it now is just that it's already quite fiddly to change and that will only get worse as the number of places the name turns up increases. We'll also need this before implementing location support in the python version.

A few bits here help get us toward making the local location a bit less weird (it exists in the location list properly now) and towards something sensible to describe locations (not yet exposed to the user)

For now at least, the id should never leak out to the user, and we require names everywhere.

Merge after #9, for the diff see https://github.com/mrc-ide/outpack/compare/mrc-3093...mrc-3056