### PR TITLE
Allow marking files as ignored

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,6 @@
-linters: with_defaults(
+linters: linters_with_defaults(
     object_length_linter = NULL,
     object_usage_linter = NULL,
-    todo_comment_linter = NULL,
     cyclocomp_linter = NULL
     )
 exclusions: list("tests/testthat.R", "R/cpp11.R")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     withr
->>>>>>> Allow marking files as ignored
 Config/testthat/edition: 3
 Remotes:
     ropensci/jsonvalidate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,9 @@ Suggests:
     knitr,
     mockery,
     rmarkdown,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
+>>>>>>> Allow marking files as ignored
 Config/testthat/edition: 3
 Remotes:
     ropensci/jsonvalidate

--- a/R/config.R
+++ b/R/config.R
@@ -108,8 +108,9 @@ config_serialise <- function(config, path) {
     c(lapply(loc[setdiff(names(loc), "args")], scalar),
       list(args = lapply(loc$args[[1]], scalar)))
   }
-  config$location <- lapply(seq_len(nrow(config$location)), function(i)
-    prepare_location(config$location[i, ]))
+  config$location <- lapply(seq_len(nrow(config$location)), function(i) {
+    prepare_location(config$location[i, ])
+  })
 
   to_json(config, "config")
 }

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -1,7 +1,7 @@
 outpack_metadata_create <- function(path, name, id, time, files,
                                     depends, parameters,
                                     script, custom, session,
-                                    file_hash,
+                                    file_hash, file_ignore,
                                     hash_algorithm) {
   assert_scalar_character(name)
   assert_scalar_character(id)
@@ -22,6 +22,10 @@ outpack_metadata_create <- function(path, name, id, time, files,
   } else {
     assert_relative_path(files, no_dots = TRUE)
     assert_file_exists(files, path)
+  }
+
+  if (length(file_ignore) > 0) {
+    files <- setdiff(files, file_ignore)
   }
 
   ## In the most simple case we could just do nothing about inputs vs

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -118,9 +118,10 @@ outpack_metadata_load <- function(json) {
                            hash = vcapply(data$files, "[[", "hash"))
   data$depends <- data_frame(
     id = vcapply(data$depends, "[[", "id"),
-    files = I(lapply(data$depends, function(x)
+    files = I(lapply(data$depends, function(x) {
       data_frame(here = vcapply(x$files, "[[", "here"),
-                 there = vcapply(x$files, "[[", "there")))))
+                 there = vcapply(x$files, "[[", "there"))
+    })))
 
   data
 }

--- a/R/packet.R
+++ b/R/packet.R
@@ -254,14 +254,16 @@ outpack_packet_add_custom <- function(application, data, schema = NULL) {
 
   tryCatch(
     jsonlite::parse_json(data),
-    error = function(e)
-      stop("Syntax error in custom metadata: ", e$message, call. = FALSE))
+    error = function(e) {
+      stop("Syntax error in custom metadata: ", e$message, call. = FALSE)
+    })
 
   if (should_validate_schema(schema)) {
     tryCatch(
       custom_schema(schema)$validate(data, error = TRUE),
-      error = function(e)
-        stop("Validating custom metadata failed: ", e$message, call. = FALSE))
+      error = function(e) {
+        stop("Validating custom metadata failed: ", e$message, call. = FALSE)
+      })
   }
 
   if (application %in% vcapply(p$custom, "[[", "application")) {

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -6,8 +6,9 @@ validate_parameters <- function(parameters) {
   assert_named(parameters, unique = TRUE)
   ## NOTE: technically this allows raw and complex through, which is a
   ## bit undesirable but unlikely
-  ok <- vlapply(parameters, function(x)
-    length(x) == 1 && is.atomic(x) && !is.na(x))
+  ok <- vlapply(parameters, function(x) {
+    length(x) == 1 && is.atomic(x) && !is.na(x)
+  })
   if (!all(ok)) {
     stop(sprintf("All parameters must be scalar atomics: error for %s",
                  paste(squote(names(parameters)[!ok]), collapse = ", ")))

--- a/man/outpack_packet_file.Rd
+++ b/man/outpack_packet_file.Rd
@@ -5,7 +5,7 @@
 \alias{outpack_packet_file_list}
 \title{Mark files during packet run}
 \usage{
-outpack_packet_file_mark(files, status = "immutable")
+outpack_packet_file_mark(files, status)
 
 outpack_packet_file_list()
 }
@@ -13,13 +13,14 @@ outpack_packet_file_list()
 \item{files}{A character vector of relative paths}
 
 \item{status}{A status to mark the file with. Must be "immutable"
-for now, later we will expand this.}
+or "ignored"}
 }
 \value{
+Depending on function
 \itemize{
 \item \code{outpack_packet_file_mark} returns nothing
 \item \code{outpack_packet_file_list} returns a \link{data.frame} with columns
-\code{path} and \code{status} (\code{immutable} or \code{unknown})
+\code{path} and \code{status} (\code{immutable}, \code{ignored} or \code{unknown})
 }
 }
 \description{

--- a/tests/testthat/helper-outpack.R
+++ b/tests/testthat/helper-outpack.R
@@ -47,3 +47,32 @@ create_random_packet_chain <- function(root, length) {
 
   id
 }
+
+
+create_temporary_root <- function(...) {
+  path <- tempfile()
+  withr::defer_parent(unlink(path, recursive = TRUE))
+  outpack_init(path, ...)
+}
+
+
+## A really simple example that we use in a few places
+create_temporary_simple_src <- function() {
+  path <- tempfile()
+  withr::defer_parent(unlink(path, recursive = TRUE))
+  fs::dir_create(path)
+
+  path <- tempfile()
+  fs::dir_create(path)
+  writeLines(c(
+    "d <- read.csv('data.csv')",
+    "png('zzz.png')",
+    "plot(d)",
+    "dev.off()"),
+    file.path(path, "script.R"))
+  write.csv(data.frame(x = 1:10, y = runif(10)),
+            file.path(path, "data.csv"),
+            row.names = FALSE)
+
+  path
+}

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -11,7 +11,8 @@ test_that("Can construct metadata with parameters", {
                                   depends = NULL,
                                   custom = NULL,
                                   session = NULL,
-                                  file_hash = NULL)
+                                  file_hash = NULL,
+                                  file_ignore = NULL)
   d <- outpack_metadata_load(json)
   expect_equal(d$parameters, parameters)
 })

--- a/tests/testthat/test-packet.R
+++ b/tests/testthat/test-packet.R
@@ -504,14 +504,14 @@ test_that("Can hash files on startup", {
   p <- outpack_packet_start(path_src, "example", root = root)
   expect_equal(outpack_packet_file_list(),
                data_frame(path = inputs, status = "unknown"))
-  outpack_packet_file_mark(inputs)
+  outpack_packet_file_mark(inputs, "immutable")
   expect_equal(outpack_packet_file_list(),
                data_frame(path = inputs, status = "immutable"))
   outpack_packet_run("script.R")
   expect_equal(outpack_packet_file_list(),
                data_frame(path = c(inputs, "zzz.png"),
                           status = c("immutable", "immutable", "unknown")))
-  outpack_packet_file_mark("zzz.png")
+  outpack_packet_file_mark("zzz.png", "immutable")
   expect_equal(outpack_packet_file_list(),
                data_frame(path = c(inputs, "zzz.png"), status = "immutable"))
   outpack_packet_end()
@@ -544,7 +544,7 @@ test_that("Can detect changes to hashed files", {
             row.names = FALSE)
   inputs <- c("script.R", "data.csv")
   p <- outpack_packet_start(path_src, "example", root = root)
-  outpack_packet_file_mark(inputs)
+  outpack_packet_file_mark(inputs, "immutable")
   outpack_packet_run("script.R")
   expect_error(
     outpack_packet_end(),
@@ -565,10 +565,57 @@ test_that("Re-adding files triggers hash", {
   write.csv(mtcars, file.path(path_src, "data.csv"))
 
   p <- outpack_packet_start(path_src, "example", root = root)
-  outpack_packet_file_mark("data.csv")
-  expect_silent(outpack_packet_file_mark("data.csv"))
+  outpack_packet_file_mark("data.csv", "immutable")
+  expect_silent(outpack_packet_file_mark("data.csv", "immutable"))
   expect_length(outpack_packet_current()$files, 1)
   file.create(file.path(path_src, "data.csv"))
-  expect_error(outpack_packet_file_mark("data.csv"),
+  expect_error(outpack_packet_file_mark("data.csv", "immutable"),
                "File was changed after being added: 'data.csv'")
+})
+
+
+test_that("Can ignore files from the final packet", {
+  on.exit(outpack_packet_clear(), add = TRUE)
+  root <- create_temporary_root(path_archive = "archive", use_file_store = TRUE)
+  path_src <- create_temporary_simple_src()
+
+  inputs <- c("data.csv", "script.R")
+
+  p <- outpack_packet_start(path_src, "example", root = root)
+  expect_equal(outpack_packet_file_list(),
+               data_frame(path = inputs, status = "unknown"))
+  outpack_packet_file_mark("data.csv", "ignored")
+  expect_equal(outpack_packet_file_list(),
+               data_frame(path = inputs, status = c("ignored", "unknown")))
+  outpack_packet_run("script.R")
+  expect_equal(outpack_packet_file_list(),
+               data_frame(path = c(inputs, "zzz.png"),
+                          status = c("ignored", "unknown", "unknown")))
+  outpack_packet_end()
+
+  meta <- root$metadata(p$id)
+  expect_equal(meta$files$path, c("script.R", "zzz.png"))
+  expect_length(root$files$list(), 2)
+  expect_setequal(dir(file.path(root$path, "archive", "example", p$id)),
+                  c("script.R", "zzz.png"))
+  expect_setequal(dir(path_src),
+                  c("data.csv", "script.R", "zzz.png"))
+})
+
+
+test_that("Files cannot be immutable and ignored", {
+  on.exit(outpack_packet_clear(), add = TRUE)
+  root <- create_temporary_root(path_archive = "archive", use_file_store = TRUE)
+  path_src <- create_temporary_simple_src()
+
+  p <- outpack_packet_start(path_src, "example", root = root)
+  outpack_packet_file_mark("data.csv", "ignored")
+  outpack_packet_file_mark("script.R", "immutable")
+
+  expect_error(
+    outpack_packet_file_mark("data.csv", "immutable"),
+    "Cannot mark ignored files as immutable: 'data.csv'")
+  expect_error(
+    outpack_packet_file_mark("script.R", "ignored"),
+    "Cannot mark immutable files as ignored: 'script.R'")
 })

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -145,14 +145,10 @@ test_that("Scope queries", {
   on.exit(unlink(tmp, recursive = TRUE))
   root <- outpack_init(tmp, use_file_store = TRUE)
 
-  x1 <- vcapply(1:3, function(i)
-    create_random_packet(tmp, "x", list(a = 1)))
-  x2 <- vcapply(1:3, function(i)
-    create_random_packet(tmp, "x", list(a = 2)))
-  y1 <- vcapply(1:3, function(i)
-    create_random_packet(tmp, "y", list(a = 1)))
-  y2 <- vcapply(1:3, function(i)
-    create_random_packet(tmp, "y", list(a = 2)))
+  x1 <- vcapply(1:3, function(i) create_random_packet(tmp, "x", list(a = 1)))
+  x2 <- vcapply(1:3, function(i) create_random_packet(tmp, "x", list(a = 2)))
+  y1 <- vcapply(1:3, function(i) create_random_packet(tmp, "y", list(a = 1)))
+  y2 <- vcapply(1:3, function(i) create_random_packet(tmp, "y", list(a = 2)))
 
   expect_equal(
     outpack_query(quote(parameter:a == 1), root = root),
@@ -178,8 +174,9 @@ test_that("location based queries", {
 
   ids <- list()
   for (name in c("x", "y", "z")) {
-    ids[[name]] <- vcapply(1:3, function(i)
-      create_random_packet(root[[name]], "data", list(p = i)))
+    ids[[name]] <- vcapply(1:3, function(i) {
+      create_random_packet(root[[name]], "data", list(p = i))
+    })
   }
   outpack_location_pull_metadata(root = path$a)
 
@@ -203,10 +200,8 @@ test_that("Can filter based on given values", {
   on.exit(unlink(tmp, recursive = TRUE))
   root <- outpack_init(tmp, use_file_store = TRUE)
 
-  x1 <- vcapply(1:3, function(i)
-    create_random_packet(tmp, "x", list(a = 1)))
-  x2 <- vcapply(1:3, function(i)
-    create_random_packet(tmp, "x", list(a = 2)))
+  x1 <- vcapply(1:3, function(i) create_random_packet(tmp, "x", list(a = 1)))
+  x2 <- vcapply(1:3, function(i) create_random_packet(tmp, "x", list(a = 2)))
 
   expect_equal(
     outpack_query(quote(latest(parameter:a == this:a)),
@@ -267,8 +262,9 @@ test_that("Can filter query to packets that are locally available (unpacked)", {
 
   ids <- list()
   for (name in c("x", "y", "z")) {
-    ids[[name]] <- vcapply(1:3, function(i)
-      create_random_packet(root[[name]], "data", list(p = i)))
+    ids[[name]] <- vcapply(1:3, function(i) {
+      create_random_packet(root[[name]], "data", list(p = i))
+    })
   }
   outpack_location_pull_metadata(root = path$a)
 


### PR DESCRIPTION
This will be useful for orderly2 because we can ignore any unaccounted-for files, which is fairly close to the current behaviour. It also allows people to exclude very large files from the final packet more easily