### PR TITLE
Allow filtering query based on unpackedness

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/query.R
+++ b/R/query.R
@@ -11,12 +11,19 @@
 ##' @param scope Optionally, a scope query to limit the packets
 ##'   searched by `pars`
 ##'
+##' @param require_unpacked Logical, indicating if we should require
+##'   that the packets are unpacked. If `FALSE` (the default) we
+##'   search through all packets known to this outpack root,
+##'   regardless of if they are locally available, but if `TRUE`, only
+##'   unpacked packets will be considered.
+##'
 ##' @param root The outpack root. Will be searched for from the
 ##'   current directory if not given.
 ##'
 ##' @return A character vector of matching ids
 ##' @export
-outpack_query <- function(expr, pars = NULL, scope = NULL, root = NULL) {
+outpack_query <- function(expr, pars = NULL, scope = NULL,
+                          require_unpacked = FALSE, root = NULL) {
   root <- outpack_root_open(root, locate = TRUE)
   expr_parsed <- query_parse(expr)
   validate_parameters(pars)
@@ -38,6 +45,10 @@ outpack_query <- function(expr, pars = NULL, scope = NULL, root = NULL) {
   if (!is.null(scope)) {
     ids <- outpack_query(scope, pars, NULL, root)
     index <- index[index$id %in% ids, ]
+  }
+
+  if (require_unpacked) {
+    index <- index[index$id %in% idx$unpacked$packet, ]
   }
 
   query_eval(expr_parsed, index, pars)

--- a/R/query.R
+++ b/R/query.R
@@ -43,11 +43,9 @@ outpack_query <- function(expr, pars = NULL, scope = NULL,
     location = I(location))
 
   if (!is.null(scope)) {
-    ids <- outpack_query(scope, pars, NULL, root)
+    ids <- outpack_query(scope, pars, NULL, require_unpacked, root)
     index <- index[index$id %in% ids, ]
-  }
-
-  if (require_unpacked) {
+  } else if (require_unpacked) {
     index <- index[index$id %in% idx$unpacked$packet, ]
   }
 

--- a/man/outpack_query.Rd
+++ b/man/outpack_query.Rd
@@ -4,7 +4,13 @@
 \alias{outpack_query}
 \title{Query outpack's database}
 \usage{
-outpack_query(expr, pars = NULL, scope = NULL, root = NULL)
+outpack_query(
+  expr,
+  pars = NULL,
+  scope = NULL,
+  require_unpacked = FALSE,
+  root = NULL
+)
 }
 \arguments{
 \item{expr}{The query expression}
@@ -14,6 +20,12 @@ into the query (using the \verb{this:} prefix)}
 
 \item{scope}{Optionally, a scope query to limit the packets
 searched by \code{pars}}
+
+\item{require_unpacked}{Logical, indicating if we should require
+that the packets are unpacked. If \code{FALSE} (the default) we
+search through all packets known to this outpack root,
+regardless of if they are locally available, but if \code{TRUE}, only
+unpacked packets will be considered.}
 
 \item{root}{The outpack root. Will be searched for from the
 current directory if not given.}

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -251,3 +251,44 @@ test_that("switch statements will prevent regressions", {
     "Unhandled operator [outpack bug - please report]",
     fixed = TRUE)
 })
+
+
+test_that("Can filter query to packets that are locally available (unpacked)", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE))
+  path <- root <- list()
+  path$a <- file.path(tmp, "a")
+  outpack_init(path$a, use_file_store = TRUE)
+  for (name in c("x", "y", "z")) {
+    path[[name]] <- file.path(tmp, name)
+    root[[name]] <- outpack_init(path[[name]], use_file_store = TRUE)
+    outpack_location_add(name, path[[name]], root = path$a)
+  }
+
+  ids <- list()
+  for (name in c("x", "y", "z")) {
+    ids[[name]] <- vcapply(1:3, function(i)
+      create_random_packet(root[[name]], "data", list(p = i)))
+  }
+  outpack_location_pull_metadata(root = path$a)
+
+  expect_equal(
+    outpack_query(quote(at_location("x", "y")), root = path$a),
+    c(ids$x, ids$y))
+  expect_equal(
+    outpack_query(quote(at_location("x", "y")), require_unpacked = TRUE,
+                  root = path$a),
+    character())
+
+  for (i in ids$x) {
+    outpack_location_pull_packet(i, root = path$a)
+  }
+
+  expect_equal(
+    outpack_query(quote(at_location("x", "y")), root = path$a),
+    c(ids$x, ids$y))
+  expect_equal(
+    outpack_query(quote(at_location("x", "y")), require_unpacked = TRUE,
+                  root = path$a),
+    ids$x)
+})


### PR DESCRIPTION
Small additional feature allowing the query to easily restrict search to unpacked packet.

The alternative here would be to put this as part of the scope query (e.g., via a query function `is_unpacked()`), which would be easy enough to move to later.