### PR TITLE
Allow searching on ids

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/constants.R
+++ b/R/constants.R
@@ -1,3 +1,5 @@
 local <- "local"
 orphan <- "orphan"
 location_reserved_name <- c("local", "orphan")
+## NOTE: could read this from id.json
+re_id <- "^([0-9]{8}-[0-9]{6}-[[:xdigit:]]{8})$"

--- a/R/id.R
+++ b/R/id.R
@@ -16,8 +16,7 @@ outpack_id <- function() {
 
 validate_outpack_id <- function(id) {
   assert_scalar_character(id)
-  ## NOTE: could read this from id.json
-  if (!grepl("^[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$", id)) {
+  if (!grepl(re_id, id)) {
     stop(sprintf("Malformed id '%s'", id), call. = FALSE)
   }
 }

--- a/R/query.R
+++ b/R/query.R
@@ -272,9 +272,13 @@ query_eval_latest <- function(query, index, pars) {
 
 query_eval_single <- function(query, index, pars) {
   candidates <- query_eval(query$args[[1]], index, pars)
-  if (length(candidates) != 1) {
-    query_eval_error("Query did not produce exactly one id",
-                     query$expr, query$context)
+  len <- length(candidates)
+  if (len == 0) {
+    query_eval_error("Query did not find any packets", query$expr, query$context)
+  } else if (len > 1) {
+    query_eval_error(
+      sprintf("Query found %d packets, but expected exactly one", len),
+      query$expr, query$context)
   }
   candidates
 }

--- a/R/query.R
+++ b/R/query.R
@@ -274,7 +274,8 @@ query_eval_single <- function(query, index, pars) {
   candidates <- query_eval(query$args[[1]], index, pars)
   len <- length(candidates)
   if (len == 0) {
-    query_eval_error("Query did not find any packets", query$expr, query$context)
+    query_eval_error("Query did not find any packets",
+                     query$expr, query$context)
   } else if (len > 1) {
     query_eval_error(
       sprintf("Query found %d packets, but expected exactly one", len),

--- a/R/root.R
+++ b/R/root.R
@@ -160,12 +160,8 @@ outpack_root_open <- function(path, locate = TRUE) {
 
 
 read_location <- function(location_id, root_path, prev) {
-  ## TODO: If we're more relaxed here about format, then this will
-  ## need changing.  This regex will end up moving somewhere central
-  ## in the package in that case.
-  re <- "^([0-9]{8}-[0-9]{6}-[[:xdigit:]]{8})$"
   path <- file.path(root_path, ".outpack", "location", location_id)
-  packets <- dir(path, re)
+  packets <- dir(path, re_id)
   is_new <- !(packets %in% prev$packet[prev$location == location_id])
   if (!any(is_new)) {
     return(NULL)

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -288,3 +288,30 @@ test_that("Can filter query to packets that are locally available (unpacked)", {
                   root = path$a),
     ids$x)
 })
+
+
+test_that("Parse literal id query", {
+  id <- "20220722-085951-148b7686"
+  res <- query_parse(id)
+  expect_identical(query_parse(bquote(single(id == .(id)))), res)
+  expect_equal(res$type, "single")
+  expect_length(res$args, 1)
+  expect_equal(res$args[[1]]$type, "test")
+  expect_equal(res$args[[1]]$name, "==")
+  expect_length(res$args[[1]]$args, 2)
+  expect_equal(res$args[[1]]$args[[1]], list(type = "lookup", name = "id"))
+  expect_equal(res$args[[1]]$args[[2]], list(type = "literal", value = id))
+})
+
+
+test_that("outpack_query allows ids", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE))
+  root <- outpack_init(tmp, use_file_store = TRUE)
+  ids <- vcapply(1:3, function(i) create_random_packet(tmp))
+  expect_identical(outpack_query(ids[[1]], root = root), ids[[1]])
+  expect_identical(outpack_query(ids[[2]], root = root), ids[[2]])
+  expect_error(
+    outpack_query("20220722-085951-148b7686", root = root),
+    "Query did not produce exactly one id")
+})

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -230,8 +230,7 @@ test_that("single requires exactly one packet", {
   on.exit(unlink(tmp, recursive = TRUE))
   root <- outpack_init(tmp, use_file_store = TRUE)
 
-  ids <- vcapply(1:3, function(i)
-    create_random_packet(tmp, "x", list(a = i)))
+  ids <- vcapply(1:3, function(i) create_random_packet(tmp, "x", list(a = i)))
   expect_equal(outpack_query(quote(single(parameter:a == 2)), root = root),
                ids[[2]])
   expect_error(outpack_query(quote(single(parameter:a >= 2)), root = root),

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -225,6 +225,22 @@ test_that("Can filter based on given values", {
 })
 
 
+test_that("single requires exactly one packet", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE))
+  root <- outpack_init(tmp, use_file_store = TRUE)
+
+  ids <- vcapply(1:3, function(i)
+    create_random_packet(tmp, "x", list(a = i)))
+  expect_equal(outpack_query(quote(single(parameter:a == 2)), root = root),
+               ids[[2]])
+  expect_error(outpack_query(quote(single(parameter:a >= 2)), root = root),
+               "Query found 2 packets, but expected exactly one")
+  expect_error(outpack_query(quote(single(parameter:a > 10)), root = root),
+               "Query did not find any packets")
+})
+
+
 test_that("switch statements will prevent regressions", {
   skip_if_not_installed("mockery")
   mockery::stub(query_parse_expr, "query_parse_check_call",
@@ -315,5 +331,5 @@ test_that("outpack_query allows ids", {
   expect_identical(outpack_query(ids[[2]], root = root), ids[[2]])
   expect_error(
     outpack_query("20220722-085951-148b7686", root = root),
-    "Query did not produce exactly one id")
+    "Query did not find any packets")
 })

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -78,24 +78,26 @@ test_that("at_location requires string literal arguments", {
     fixed = TRUE)
 
   res <- query_parse(quote(at_location("a", "b")))
-  expect_equal(res,
-               list(type = "at_location",
-                    args = list(list(type = "literal", value = "a"),
-                                list(type = "literal", value = "b"))))
+  expect_equal(res$type, "at_location")
+  expect_equal(res$args, list(list(type = "literal", value = "a"),
+                              list(type = "literal", value = "b")))
 })
 
 
 test_that("Queries can only be name and parameter", {
-  expect_equal(
-    query_parse(quote(name == "data")),
-    list(type = "test", name = "==",
-         args = list(list(type = "lookup", name = "name"),
-                     list(type = "literal", value = "data"))))
-  expect_equal(
-    query_parse(quote(parameter:x == 1)),
-    list(type = "test", name = "==",
-         args = list(list(type = "lookup", name = "parameter", query = "x"),
-                     list(type = "literal", value = 1))))
+  res <- query_parse(quote(name == "data"))
+  expect_equal(res$type, "test")
+  expect_equal(res$name, "==")
+  expect_equal(res$args,
+               list(list(type = "lookup", name = "name"),
+                    list(type = "literal", value = "data")))
+
+  res <- query_parse(quote(parameter:x == 1))
+  expect_equal(res$type, "test")
+  expect_equal(res$name, "==")
+  expect_equal(res$args,
+               list(list(type = "lookup", name = "parameter", query = "x"),
+                    list(type = "literal", value = 1)))
   expect_error(
     query_parse(quote(date >= "2022-02-04")),
     "Unhandled query expression value 'date'")

--- a/vignettes/query.Rmd
+++ b/vignettes/query.Rmd
@@ -39,7 +39,7 @@ parameter:x > 1
 
 Every "test" uses a boolean operator (`<`, `>`, `<=`, `>=`, `==`, or `!=`) and the left and right hand side can be one of:
 
-* a lookup into the outpack metadata (`parameter:x` is the value of a parameter called `x`, `name` is the name of the packet)
+* a lookup into the outpack metadata (`parameter:x` is the value of a parameter called `x`, `name` is the name of the packet, and `id` is the id of a packet)
 * a lookup into the provided data `pars` (`this:x` is the value of `pars$x`)
 * a literal value (e.g., `"some_name"`, `1`, or `TRUE`)
 
@@ -49,10 +49,18 @@ Tests can be grouped together `(`, `!`, `&&`, and `||` as you might expect:
 * `name == "data" && parameter:x > 3` finds packets called "data" where parameter `x` is greater than 3
 * `(parameter:y == 2) && !(parameter:x == 1 || parameter:x == 2)` finds where parameter `y` is 2 and parameter `x` is anything other than 1 or 2 (could also be written `(parameter:y == 2) && (parameter:x != 1 && parameter:x != 2)`)
 
-There are two other functions
+There are three other functions
 
-* `latest(expr)` finds the latest packet satifying `expr` - it always returns a length 1 character, but this is `NA_character_` if no suitable packet is found
+* `latest(expr)` finds the latest packet satifying `expr` - it always returns a length 1 character, but this is `NA_character_` if no suitable packet is found. If no `expr` is given then the latest of all packets is returned.
+* `single(expr)` is like `latest(expr)` except that it is an error if `expr` does not evaluate to exactly one packet id
 * `at_location("loc1", "loc2")` finds packets that are available at any of the locations provided (here, `"loc1"` or `"loc2"`; any number of locations can be provided, these must be string literals).
+
+## Special simple queries
+
+There are two shorthand queries:
+
+* `latest` is equivalent to `latest()` (most useful when applied with a scope)
+* a string matching the regular expression for an id (`^([0-9]{8}-[0-9]{6}-[[:xdigit:]]{8})$`) is equivalent to `single(id == "<id>")` where `"<id>"` is the string provided)
 
 ## Scoping queries
 


### PR DESCRIPTION
Merge after #17, as this PR contains those commits

This PR allows a query that contains a plain id, which we use in orderly and had forgot. So in the orderly.yml we might have:

```
depends:
  - minimal:
      id: ""20220722-085951-148b7686""
      use:
        graph.png: mygraph.png
```

To make this work, we allow `outpack_query` to accept a string argument that contains an id (validated by the same regex we use elsewhere) and translate this to `single(id == "20220722-085951-148b7686")`. To support *that* I've introduced some new bits to the query DSL

* `single(expr)` is like latest but requires that the `expr` ends up being exactly one id - that is automatically satisfied here of course
* `id == <id>` does an id lookup the same way that `name == <name>` currently does

I've also generalised the context-including expression parse errors to work for evaluation errors so that if the lookup fails the user gets some sensible information