### PR TITLE
Fix queries in empty outpack repo on older R versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/query.R
+++ b/R/query.R
@@ -36,7 +36,7 @@ outpack_query <- function(expr, pars = NULL, scope = NULL,
   i <- match(idx$location$location, root$config$location$id)
   location <- split(root$config$location$name[i], idx$location$packet)
   index <- data_frame(
-    id = names(root$index()$metadata),
+    id = names(root$index()$metadata) %||% character(0),
     name = vcapply(root$index()$metadata, "[[", "name"),
     ## Wrap these in I() because they're list columns
     parameters = I(lapply(root$index()$metadata, "[[", "parameters")),

--- a/R/query.R
+++ b/R/query.R
@@ -324,6 +324,11 @@ query_eval_test <- function(query, index, pars) {
 
 query_eval_test_binary <- function(op, a, b) {
   op <- match.fun(op)
+  ## Older versions of R do not allow mixing of zero and non-zero
+  ## length inputs here, but we can do this ourselves:
+  if (length(a) == 0 || length(b) == 0) {
+    return(logical(0))
+  }
   vlapply(Map(function(a, b) !is.null(a) && !is.null(b) && op(a, b),
               a, b, USE.NAMES = FALSE),
           identity)

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -332,3 +332,13 @@ test_that("outpack_query allows ids", {
     outpack_query("20220722-085951-148b7686", root = root),
     "Query did not find any packets")
 })
+
+
+test_that("correct behaviour with empty queries", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE))
+  root <- outpack_init(tmp, use_file_store = TRUE)
+  expect_equal(outpack_query("latest", root = root), NA_character_)
+  expect_equal(outpack_query(quote(name == "data"), root = root),
+               character(0))
+})


### PR DESCRIPTION
This is the reason for the failing test on https://github.com/vimc/orderly2/pull/4 on oldrel-1, the behaviour of Map has changed in recent R and we don't allow for the previous behavoiur.

Fix is just not to let a mix of zero and nonzero length inputs make it into Map, so we just return `logical(0)`. There's also a smaller issue where we used to return `NULL` and not `character(0)` in an empty repo, because the index did not have `id` set correctly.