### PR TITLE
mrc-3539 add path_archive

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -135,8 +135,8 @@ config_set_path_archive <- function(value, root) {
     }
     config$core$path_archive <- value
   } else {
-    assert_relative_path(value, name = "path_archive")
     path_archive <- file.path(root$path, value)
+    assert_relative_path(value, name = "path_archive")
     assert_directory_does_not_exist(path_archive)
     tryCatch({
       fs::dir_create(path_archive)

--- a/R/store.R
+++ b/R/store.R
@@ -23,11 +23,12 @@ file_store <- R6::R6Class(
                 substr(dat$value, 3, nchar(dat$value)))
     },
 
-    ## TODO: bulk get, with overwrite control
+    ## TODO: overwrite control
     get = function(hash, dst) {
       src <- self$filename(hash)
-      if (!file.exists(src)) {
-        stop(sprintf("Hash '%s' not found in store", hash))
+      if (any(!file.exists(src))) {
+        stop(sprintf("Hash '%s' not found in store",
+                     hash[which(!file.exists(src))]))
       }
       fs::dir_create(dirname(dst))
       fs::file_copy(src, dst)

--- a/R/store.R
+++ b/R/store.R
@@ -28,7 +28,7 @@ file_store <- R6::R6Class(
       src <- self$filename(hash)
       if (any(!file.exists(src))) {
         stop(sprintf("Hash '%s' not found in store",
-                     hash[which(!file.exists(src))]))
+                     hash[!file.exists(src)]))
       }
       fs::dir_create(dirname(dst))
       fs::file_copy(src, dst)

--- a/R/store.R
+++ b/R/store.R
@@ -23,7 +23,7 @@ file_store <- R6::R6Class(
                 substr(dat$value, 3, nchar(dat$value)))
     },
 
-    ## TODO: overwrite control
+    ## TODO: bulk get, with overwrite control
     get = function(hash, dst) {
       src <- self$filename(hash)
       if (any(!file.exists(src))) {

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -110,6 +110,27 @@ assert_file_exists <- function(x, workdir = NULL, name = "File") {
 }
 
 
+assert_directory_does_not_exist <- function(x, name = "Directory") {
+  ok <- !fs::dir_exists(x)
+  if (!all(ok)) {
+    stop(sprintf("%s already exists: %s",
+                 name, paste(squote(x[!ok]), collapse = ", ")))
+  }
+
+  ## TODO: we should (as orderly does) verify that the casing is
+  ## correct here (avoiding README.MD/README.md confusion), but that's
+  ## actually quite hard to pull off.  Either we need to pull in the
+  ## enormous mess of code in orderly, or we can just about achive
+  ## this by looking at the fs::path_real(x) and stripping leading
+  ## path parts with fs::path_rel().  This does do very badly in the
+  ## case of symlinks though (e.g., macOS tempdir) and windows
+  ## shortened paths (e.g., Windows - orderly struggles there
+  ## generally too). (See 1170cc9)
+
+  invisible(x)
+}
+
+
 assert_directory <- function(x, workdir = NULL, name = "Directory") {
   assert_file_exists(x, workdir, name)
   if (!fs::is_dir(x)) {

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -286,8 +286,9 @@ test_that("Archive is not added if file store is corrupt", {
   id <- create_random_packet_chain(root, 3)
   hash <- root$metadata(id[["c"]])$files$hash
   fs::file_delete(root$files$filename(hash[[1]]))
+  e <- "Error adding 'path_archive': Hash 'sha256(.*)' not found in store"
   expect_error(outpack_config_set(core.path_archive = "archive", root = root),
-               "Error adding 'path_archive': Hash 'sha256(.*)' not found in store")
+               e)
 
   expect_null(root$config$core$path_archive)
   expect_false(fs::dir_exists(file.path(path, "archive")))

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -298,6 +298,28 @@ test_that("Archive is not added if file store is corrupt", {
 })
 
 
+test_that("Validates path_archive", {
+  path <- tempfile()
+  on.exit(unlink(path, recursive = TRUE))
+  root <- outpack_init(path, path_archive = NULL, use_file_store = TRUE)
+  expect_error(outpack_config_set(core.path_archive = "/archive", root = root),
+               "'path_archive' must be relative path")
+  expect_null(root$config$core$path_archive)
+
+  dir.create(file.path(path, "archive"))
+  expect_error(outpack_config_set(core.path_archive = "archive", root = root),
+               "Directory already exists")
+  expect_null(root$config$core$path_archive)
+
+  outpack_config_set(core.path_archive = "new-archive", root = root)
+  expect_error(outpack_config_set(core.path_archive = "/archive", root = root),
+               "'path_archive' must be relative path")
+  expect_error(outpack_config_set(core.path_archive = "archive", root = root),
+               "Directory already exists")
+  expect_equal(root$config$core$path_archive, "new-archive")
+})
+
+
 test_that("Enabling recursive pulls forces pulling missing packets", {
   path <- tempfile()
   on.exit(unlink(path, recursive = TRUE))

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -106,8 +106,9 @@ test_that("Can add file_store", {
   hash_pulled <- root$dst$metadata(id[["c"]])$files$hash
   expect_equal(length(hash_pulled), 3)
 
-  dest <- tempdir()
-  on.exit(unlink(dest, recursive = TRUE))
+  dest <- tempfile()
+  dir.create(dest)
+  on.exit(unlink(path, recursive = TRUE))
   root$dst$files$get(hash_pulled[[1]], dest)
   root$dst$files$get(hash_pulled[[2]], dest)
   root$dst$files$get(hash_pulled[[3]], dest)
@@ -156,8 +157,9 @@ test_that("Files will be searched for by hash when adding file store", {
 
   expect_true(root$config$core$use_file_store)
 
-  dest <- tempdir()
-  on.exit(unlink(dest, recursive = TRUE))
+  dest <- tempfile()
+  dir.create(dest)
+  on.exit(unlink(path, recursive = TRUE))
   root$files$get(root$metadata(id)$files$hash, dest)
 })
 
@@ -270,7 +272,8 @@ test_that("Can add archive", {
   hash <- root$metadata(id[["c"]])$files$hash
   expect_equal(length(hash), 3)
 
-  dest <- tempdir()
+  dest <- tempfile()
+  dir.create(dest)
   on.exit(unlink(dest, recursive = TRUE))
   root$files$get(hash[[1]], dest)
   root$files$get(hash[[2]], dest)

--- a/tests/testthat/test-file-store.R
+++ b/tests/testthat/test-file-store.R
@@ -34,4 +34,6 @@ test_that("Can store files", {
   expect_length(obj$list(), 10)
   expect_equal(file.exists(obj$filename(obj$list())),
                rep(TRUE, 10))
+  dest <- tempdir()
+  obj$get(obj$list(), dest)
 })

--- a/tests/testthat/test-file-store.R
+++ b/tests/testthat/test-file-store.R
@@ -34,6 +34,8 @@ test_that("Can store files", {
   expect_length(obj$list(), 10)
   expect_equal(file.exists(obj$filename(obj$list())),
                rep(TRUE, 10))
-  dest <- tempdir()
+  dest <- tempfile()
+  dir.create(dest)
+  on.exit(unlink(dest, recursive = TRUE))
   obj$get(obj$list(), dest)
 })


### PR DESCRIPTION
Allow `path_archive` to be added where it did not previously exist.