### PR TITLE
Add http remote type

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,9 +33,11 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - name: Install Linux system dependencies
-        if: runner.os == "Linux"
-        run: sudo apt install libsodium-dev
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          set -x
+          sudo apt install libsodium-dev
 
       - uses: r-lib/actions/setup-r@v1
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,6 +33,10 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
+      - name: Install Linux system dependencies
+        if: runner.os == "Linux"
+        run: sudo apt install libsodium-dev
+
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Suggests:
     jsonvalidate (>= 1.4.0),
     knitr,
     mockery,
+    remotes,
     rmarkdown,
     testthat (>= 3.0.0),
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     jsonlite,
     openssl
 Suggests:
+    httr,
     jsonvalidate (>= 1.4.0),
     knitr,
     mockery,

--- a/R/http_client.R
+++ b/R/http_client.R
@@ -18,7 +18,8 @@ outpack_http_client <- R6::R6Class(
   ))
 
 
-http_client_request <- function(verb, server, path, ..., parse_json = TRUE, download = NULL) {
+http_client_request <- function(verb, server, path, ..., parse_json = TRUE,
+                                download = NULL) {
   if (is.null(download)) {
     response <- verb(paste0(server, path), ...)
   } else {

--- a/R/http_client.R
+++ b/R/http_client.R
@@ -1,0 +1,105 @@
+## NOTE: none of the auth bits here are done yet - we have a system in
+## the orderlyweb client that lets us do this in a fairly pluggable
+## way, supporting username/password and token based auth (with the
+## former getting a token via username/password)
+outpack_http_client <- R6::R6Class(
+  "outpack_http_client",
+
+  public = list(
+    url = NULL,
+
+    initialize = function(url) {
+      self$url <- url
+    },
+
+    get = function(path, ...) {
+      http_client_request(httr::GET, self$url, path, ...)
+    }
+  ))
+
+
+http_client_request <- function(verb, server, path, ..., parse_json = TRUE, download = NULL) {
+  if (is.null(download)) {
+    response <- verb(paste0(server, path), ...)
+  } else {
+    response <- verb(paste0(server, path), ...,
+                     http_client_download_options(download))
+  }
+
+  http_client_handle_error(response)
+  if (is.null(download)) {
+    txt <- httr::content(response, "text", encoding = "UTF-8")
+    if (parse_json) {
+      from_json(txt)$data
+    } else {
+      strip_response_wrapper(txt)
+    }
+  } else {
+    download
+  }
+}
+
+
+## This could probably be simplified considerably, it was designed to
+## cope with something like docker or vault where we were less in
+## control of the errors, and we can always put back in some better
+## support later.
+http_client_handle_error <- function(response) {
+  code <- httr::status_code(response)
+  if (code >= 400) {
+    txt <- httr::content(response, "text", encoding = "UTF-8")
+    res <- from_json(txt)
+    stop(http_client_error(res$errors[[1]]$detail, code, res$errors))
+  }
+  response
+}
+
+
+http_client_error <- function(msg, code, errors) {
+  err <- list(message = msg, errors = errors, code = code)
+  class(err) <- c("outpack_http_client_error", "error", "condition")
+  err
+}
+
+
+http_client_download_options <- function(dest) {
+  c(httr::write_disk(dest),
+    httr::accept("application/octet-stream"))
+}
+
+
+## when we get something back from the server it will be an object
+##
+## {
+##   "status": "success",
+##   "errors": null,
+##   "data:" <payload>
+## }
+##
+## and we want to get this payload. We can't deserialise though
+## because we can't generally do a roundtrip into R objects and back
+## losslessly!
+##
+## The opions here are
+##
+## * change the server to cope with an accept = "text/plain" header to
+##   avoid adding the wrapper, which feels a bit annoying
+##
+## * take the porcelain approach and use V8 to pull out the component
+##   that we want (json_parse_extract)
+##
+## * make some dirty assumptions here about how the formatting looks
+##   and do it with regular expressions.
+##
+## We'll take the third approach here for now, as it's pretty
+## straightforward really.
+strip_response_wrapper <- function(txt) {
+  ## Could also make this whitespace insensitive by adding some '\\s*'
+  ## at every gap, but that's not likely to be needed.
+  re <- paste0("^\\{",
+               '("status":"success",|"errors":null,)*',
+               '"data":(.+?)',
+               '(,"status":"success"|,"errors":null)*',
+               "\\}$")
+  sub(re, "\\2", txt)
+}

--- a/R/http_client.R
+++ b/R/http_client.R
@@ -31,9 +31,9 @@ http_client_request <- function(verb, server, path, ..., parse_json = TRUE,
   if (is.null(download)) {
     txt <- httr::content(response, "text", encoding = "UTF-8")
     if (parse_json) {
-      from_json(txt)$data
+      from_json(txt)
     } else {
-      strip_response_wrapper(txt)
+      txt
     }
   } else {
     download
@@ -66,41 +66,4 @@ http_client_error <- function(msg, code, errors) {
 http_client_download_options <- function(dest) {
   c(httr::write_disk(dest),
     httr::accept("application/octet-stream"))
-}
-
-
-## when we get something back from the server it will be an object
-##
-## {
-##   "status": "success",
-##   "errors": null,
-##   "data:" <payload>
-## }
-##
-## and we want to get this payload. We can't deserialise though
-## because we can't generally do a roundtrip into R objects and back
-## losslessly!
-##
-## The opions here are
-##
-## * change the server to cope with an accept = "text/plain" header to
-##   avoid adding the wrapper, which feels a bit annoying
-##
-## * take the porcelain approach and use V8 to pull out the component
-##   that we want (json_parse_extract)
-##
-## * make some dirty assumptions here about how the formatting looks
-##   and do it with regular expressions.
-##
-## We'll take the third approach here for now, as it's pretty
-## straightforward really.
-strip_response_wrapper <- function(txt) {
-  ## Could also make this whitespace insensitive by adding some '\\s*'
-  ## at every gap, but that's not likely to be needed.
-  re <- paste0("^\\{",
-               '("status":"success",|"errors":null,)*',
-               '"data":(.+?)',
-               '(,"status":"success"|,"errors":null)*',
-               "\\}$")
-  sub(re, "\\2", txt)
 }

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -11,7 +11,7 @@ outpack_location_http <- R6::R6Class(
     },
 
     list = function() {
-      dat <- private$client$get("/metadata/list", parse_json = TRUE)
+      dat <- private$client$get("/metadata/list", parse_json = TRUE)$data
       data_frame(
         packet = vcapply(dat, "[[", "packet"),
         time = num_to_time(vnapply(dat, "[[", "time")),
@@ -21,7 +21,8 @@ outpack_location_http <- R6::R6Class(
     metadata = function(packet_ids) {
       ret <- vcapply(packet_ids, function(id) {
         tryCatch(
-          private$client$get(sprintf("/metadata/%s", id), parse_json = FALSE),
+          private$client$get(sprintf("/metadata/%s/text", id),
+                             parse_json = FALSE),
           outpack_http_client_error = function(e) {
             if (e$code == 404) {
               e$message <- sprintf("Some packet ids not found: '%s'", id)

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -14,13 +14,21 @@ outpack_location_http <- R6::R6Class(
       dat <- private$client$get("/metadata/list", parse_json = TRUE)
       data_frame(
         packet = vcapply(dat, "[[", "packet"),
-        time = as.POSIXct(vcapply(dat, "[[", "time"), tz = "UTC"),
+        time = num_to_time(vnapply(dat, "[[", "time")),
         hash = vcapply(dat, "[[", "hash"))
     },
 
     metadata = function(packet_ids) {
       ret <- vcapply(packet_ids, function(id) {
-        private$client$get(sprintf("/metadata/%s", id), parse_json = FALSE)
+        tryCatch(
+          private$client$get(sprintf("/metadata/%s", id), parse_json = FALSE),
+          outpack_http_client_error = function(e) {
+            if (e$code == 404) {
+              e$message <- sprintf("Some packet ids not found: '%s'", id)
+              class(e) <- c("simpleError", class(e))
+            }
+            stop(e)
+          })
       })
       names(ret) <- packet_ids
       ret
@@ -30,7 +38,18 @@ outpack_location_http <- R6::R6Class(
       ## TODO: not totally obvious how we should set the progress here
       ## (currently always FALSE), possibly via some sort of option,
       ## possibly via whatever logging interface we come up with as we
-      ## could turn it on via log levels.
-      private$client$get(sprintf("/file/%s", hash), download = dest)
+      ## could turn it on via log levels. Once we decide we can enable
+      ## progress in the client, but there's not much point until
+      ## then.
+      tryCatch(
+        private$client$get(sprintf("/file/%s", hash), download = dest),
+        outpack_http_client_error = function(e) {
+          if (e$code == 404) {
+            unlink(dest)
+            e$message <- sprintf("Hash '%s' not found at location", hash)
+            class(e) <- c("simpleError", class(e))
+          }
+          stop(e)
+        })
     }
   ))

--- a/R/location_http.R
+++ b/R/location_http.R
@@ -1,0 +1,36 @@
+outpack_location_http <- R6::R6Class(
+  "outpack_location_http",
+
+  private = list(
+    client = NULL
+  ),
+
+  public = list(
+    initialize = function(url) {
+      private$client <- outpack_http_client$new(url)
+    },
+
+    list = function() {
+      dat <- private$client$get("/metadata/list", parse_json = TRUE)
+      data_frame(
+        packet = vcapply(dat, "[[", "packet"),
+        time = as.POSIXct(vcapply(dat, "[[", "time"), tz = "UTC"),
+        hash = vcapply(dat, "[[", "hash"))
+    },
+
+    metadata = function(packet_ids) {
+      ret <- vcapply(packet_ids, function(id) {
+        private$client$get(sprintf("/metadata/%s", id), parse_json = FALSE)
+      })
+      names(ret) <- packet_ids
+      ret
+    },
+
+    fetch_file = function(hash, dest) {
+      ## TODO: not totally obvious how we should set the progress here
+      ## (currently always FALSE), possibly via some sort of option,
+      ## possibly via whatever logging interface we come up with as we
+      ## could turn it on via log levels.
+      private$client$get(sprintf("/file/%s", hash), download = dest)
+    }
+  ))

--- a/R/location_path.R
+++ b/R/location_path.R
@@ -36,7 +36,7 @@ outpack_location_path <- R6::R6Class(
       ret
     },
 
-    fetch_file = function(hash) {
+    fetch_file = function(hash, dest) {
       ## TODO: we might need to give some better hints here as to what
       ## the user was looking for, but almost certainly that's better
       ## done by the calling function.
@@ -51,6 +51,7 @@ outpack_location_path <- R6::R6Class(
           stop(sprintf("Hash '%s' not found at location", hash))
         }
       }
-      path
+      fs::file_copy(path, dest)
+      dest
     }
   ))

--- a/R/store.R
+++ b/R/store.R
@@ -45,13 +45,19 @@ file_store <- R6::R6Class(
     ## though that requires working out what the algorithm should be.
     ## Our current use knows the hash at the point of insertion and
     ## the validation is very useful!
-    put = function(src, hash) {
+    put = function(src, hash, move = FALSE) {
       hash_validate(src, hash)
       dst <- self$filename(hash)
       if (!fs::file_exists(dst)) {
         fs::dir_create(dirname(dst))
-        fs::file_copy(src, dst)
+        if (move) {
+          fs::file_move(src, dst)
+        } else {
+          fs::file_copy(src, dst)
+        }
         fs::file_chmod(dst, "a-wx")
+      } else if (move) {
+        unlink(src)
       }
       invisible(hash)
     },
@@ -65,6 +71,12 @@ file_store <- R6::R6Class(
 
     destroy = function() {
       fs::dir_delete(self$path)
+    },
+
+    tmp = function() {
+      path <- file.path(self$path, "tmp")
+      fs::dir_create(file.path(self$path, "tmp"))
+      tempfile(tmpdir = path)
     }
   )
 )

--- a/R/util.R
+++ b/R/util.R
@@ -102,6 +102,11 @@ to_json <- function(x, schema) {
 }
 
 
+from_json <- function(x, ...) {
+  jsonlite::fromJSON(x, simplifyVector = FALSE, ...)
+}
+
+
 data_frame <- function(...) {
   ret <- data.frame(..., stringsAsFactors = FALSE, check.names = FALSE)
   rownames(ret) <- NULL

--- a/tests/testthat/helper-http.R
+++ b/tests/testthat/helper-http.R
@@ -1,0 +1,31 @@
+mock_headers <- function(...) {
+  structure(list(...), class = c("insensitive", "list"))
+}
+
+mock_response <- function(content, status = 200, wrap = TRUE, download = NULL) {
+  headers <- mock_headers()
+  if (!is.null(download)) {
+    headers <- mock_headers("content-type" = "application/octet-stream")
+    writeBin(content, download)
+  } else if (inherits(content, "json")) {
+    headers <- mock_headers("content-type" = "application/json")
+    if (wrap) {
+      content <- sprintf('{"status":"success","errors":null,"data":%s}',
+                         content)
+    }
+    class(content) <- NULL
+    content <- c(writeBin(content, raw()), as.raw(0L))
+  } else {
+    stop("Unhandled mock response type")
+  }
+  structure(list(status_code = status,
+                 headers = headers,
+                 content = content),
+            class = "response")
+}
+
+
+json_string <- function(s) {
+  class(s) <- "json"
+  s
+}

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -12,7 +12,8 @@ install_deps <- function() {
   if (!requireNamespace("outpack.server", quietly = TRUE)) {
     message("Installing additional requirements")
     if (!requireNamespace("remotes", quietly = TRUE)) {
-      install.packages("remotes")
+      install.packages("remotes",
+                       repos = c(CRAN = "https://cloud.r-project.org"))
     }
     getNamespace("remotes")$install_github("mrc-ide/outpack.server@mrc-3605",
                                            upgrade = FALSE)

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -11,10 +11,6 @@
 install_deps <- function() {
   if (!requireNamespace("outpack.server", quietly = TRUE)) {
     message("Installing additional requirements")
-    if (!requireNamespace("remotes", quietly = TRUE)) {
-      install.packages("remotes",
-                       repos = c(CRAN = "https://cloud.r-project.org"))
-    }
     getNamespace("remotes")$install_github("mrc-ide/outpack.server@mrc-3605",
                                            upgrade = FALSE)
   }

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -11,7 +11,7 @@
 install_deps <- function() {
   if (!requireNamespace("outpack.server", quietly = TRUE)) {
     message("Installing additional requirements")
-    getNamespace("remotes")$install_github("mrc-ide/outpack.server@mrc-3605",
+    getNamespace("remotes")$install_github("mrc-ide/outpack.server",
                                            upgrade = FALSE)
   }
 }

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -11,7 +11,10 @@
 install_deps <- function() {
   if (!requireNamespace("outpack.server", quietly = TRUE)) {
     message("Installing additional requirements")
-    getNamespace("remotes")$install_github("mrc-ide/outpack.server",
+    if (!requireNamespace("remotes", quietly = TRUE)) {
+      install.packages("remotes")
+    }
+    getNamespace("remotes")$install_github("mrc-ide/outpack.server@mrc-3605",
                                            upgrade = FALSE)
   }
 }

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -9,7 +9,7 @@
 ## For an eventual CRAN release we'l need some other way of doing this
 ## though.
 install_deps <- function() {
-  if (!requireNamespace("outpack.server")) {
+  if (!requireNamespace("outpack.server", quietly = TRUE)) {
     message("Installing additional requirements")
     getNamespace("remotes")$install_github("mrc-ide/outpack.server",
                                            upgrade = FALSE)

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -1,0 +1,33 @@
+## A bit of sleight of hand is needed here to avoid a bit of a
+## circular dependency. We'll relax this later once we get a non-R
+## version of this sorted out.
+##
+## The getNamespace(ns)$fn constructions are equivalent to ns::fn but
+## will slide under R CMD check without warnings that would break the
+## build.
+##
+## For an eventual CRAN release we'l need some other way of doing this
+## though.
+install_deps <- function() {
+  if (!requireNamespace("outpack.server")) {
+    message("Installing additional requirements")
+    getNamespace("remotes")$install_github("mrc-ide/outpack.server",
+                                           upgrade = FALSE)
+  }
+}
+
+
+outpack_server <- function(path, validate = NULL, log_level = "info",
+                           start = TRUE) {
+  testthat::skip_on_os("windows") # does not work on gha due to install issues
+  install_deps()
+  create <- function(path, validate, log_level) {
+    getNamespace("outpack.server")$api(path, validate, log_level)
+  }
+  args <- list(path = path, validate = validate, log_level = log_level)
+  bg <- getNamespace("porcelain")$porcelain_background$new(create, args)
+  if (start) {
+    bg$start()
+  }
+  bg
+}

--- a/tests/testthat/test-file-store.R
+++ b/tests/testthat/test-file-store.R
@@ -39,3 +39,41 @@ test_that("Can store files", {
   on.exit(unlink(dest, recursive = TRUE))
   obj$get(obj$list(), dest)
 })
+
+
+test_that("can move files into place", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE))
+  dir.create(tmp)
+  for (i in 1:2) {
+    saveRDS(runif(10), file.path(tmp, letters[i]))
+  }
+  pa <- file.path(tmp, "a")
+  pb <- file.path(tmp, "b")
+  ha <- hash_file(pa)
+  hb <- hash_file(pb)
+
+  obj <- file_store$new(tempfile())
+  on.exit(unlink(obj$path, recursive = TRUE), add = TRUE)
+  obj$put(pa, ha, move = FALSE)
+  ## Original file has not been moved:
+  expect_true(file.exists(pa))
+
+  ## Moving files removes the source file whether or not a move was
+  ## completed:
+  obj$put(pa, ha, move = TRUE)
+  obj$put(pb, hb, move = TRUE)
+  expect_false(file.exists(pa))
+  expect_false(file.exists(pb))
+})
+
+
+test_that("can create a filename within the store", {
+  obj <- file_store$new(tempfile())
+  on.exit(unlink(obj$path, recursive = TRUE), add = TRUE)
+  p <- obj$tmp()
+  expect_equal(normalizePath(dirname(p)),
+               normalizePath(file.path(obj$path, "tmp")))
+  expect_false(file.exists(p))
+  expect_true(file.exists(file.path(obj$path, "tmp")))
+})

--- a/tests/testthat/test-http-client.R
+++ b/tests/testthat/test-http-client.R
@@ -1,0 +1,98 @@
+test_that("client sends well formed requests", {
+  skip_if_not_installed("mockery")
+  verb <- mockery::mock(mock_response(json_string("[1,2,3]")))
+
+  res <- http_client_request(verb, "http://example.com", "/path")
+  expect_equal(res, list(1, 2, 3))
+  mockery::expect_called(verb, 1)
+  expect_equal(mockery::mock_args(verb)[[1]],
+               list("http://example.com/path"))
+})
+
+
+test_that("client can return json verbatim as text", {
+  skip_if_not_installed("mockery")
+  ## A little whitespace here to ensure that this has not gone through
+  ## any json processor
+  verb <- mockery::mock(mock_response(json_string("[1,2, 3]")))
+
+  res <- http_client_request(verb, "http://example.com", "/path",
+                             parse_json = FALSE)
+  expect_equal(res, "[1,2, 3]")
+})
+
+
+test_that("client can download files", {
+  skip_if_not_installed("mockery")
+  content <- charToRaw("result")
+  dest <- tempfile()
+  verb <- mockery::mock(mock_response(content, download = dest))
+
+  mock_download_options <- mockery::mock(list(TRUE))
+  mockery::stub(http_client_request, "http_client_download_options",
+                mock_download_options)
+
+  res <- http_client_request(verb, "http://example.com", "/path",
+                             download = dest)
+
+  expect_identical(res, dest)
+  mockery::expect_called(verb, 1)
+  args <- mockery::mock_args(verb)[[1]]
+  expect_equal(args, list("http://example.com/path",
+                          list(TRUE)))
+
+  mockery::expect_called(mock_download_options, 1)
+  expect_equal(mockery::mock_args(mock_download_options)[[1]], list(dest))
+})
+
+
+test_that("can strip the response wrapper sensibly", {
+  content <- list(status = scalar("success"),
+                  errors = NULL,
+                  data = 1:3)
+  expected <- to_json(content$data, NULL)
+  expect_identical(strip_response_wrapper(to_json(content, NULL)), expected)
+  order <- list(c(1, 2, 3), c(1, 3, 2), c(2, 1, 3), c(2, 3, 1),
+                c(3, 1, 2), c(3, 2, 1))
+  for (i in order) {
+    expect_identical(strip_response_wrapper(to_json(content[i], NULL)),
+                     expected)
+  }
+})
+
+
+test_that("handle errors", {
+  str <- paste0(
+    '{"status":"failure",',
+    '"errors":[{"error":"NOT_FOUND","detail":"Resource not found"}],',
+    '"data":null}')
+  r <-  mock_response(json_string(str), status = 404, wrap = FALSE)
+  err <- expect_error(http_client_handle_error(r),
+                      "Resource not found")
+  expect_s3_class(err, "outpack_http_client_error")
+  expect_equal(err$code, 404)
+  expect_equal(err$errors, list(list(error = "NOT_FOUND",
+                                     detail = "Resource not found")))
+})
+
+
+test_that("can construct sensible download options", {
+  path <- tempfile()
+  res <- http_client_download_options(path)
+  expect_s3_class(res, "request")
+  expect_equal(res$headers, c(Accept = "application/octet-stream"))
+  expect_equal(res$output, httr::write_disk(path)$output)
+})
+
+
+test_that("can use the client to make requests", {
+  skip_if_not_installed("mockery")
+  cl <- outpack_http_client$new("http://example.com")
+  mock_get <- mockery::mock(mock_response(json_string("[1,2,3]")))
+  mockery::stub(cl$get, "httr::GET", mock_get)
+  res <- cl$get("/path")
+  expect_equal(res, list(1, 2, 3))
+  mockery::expect_called(mock_get, 1)
+  expect_equal(mockery::mock_args(mock_get)[[1]],
+               list("http://example.com/path"))
+})

--- a/tests/testthat/test-location-path.R
+++ b/tests/testthat/test-location-path.R
@@ -101,8 +101,11 @@ test_that("can locate files from the store", {
   idx <- root$index()
 
   h <- idx$metadata[[1]]$files$hash
-  expect_equal(normalizePath(loc$fetch_file(h)),
-               normalizePath(root$files$filename(h)))
+  dest <- tempfile()
+  on.exit(unlink(dest), add = TRUE)
+  res <- loc$fetch_file(h, dest)
+  expect_identical(res, dest)
+  expect_identical(hash_file(res), h)
 })
 
 
@@ -113,9 +116,11 @@ test_that("sensible error if file not found in store", {
   outpack_init(path, use_file_store = TRUE)
   loc <- outpack_location_path$new(path)
   h <- "md5:c7be9a2c3cd8f71210d9097e128da316"
+  dest <- tempfile()
   expect_error(
-    loc$fetch_file(h),
+    loc$fetch_file(h, dest),
     "Hash 'md5:c7be9a2c3cd8f71210d9097e128da316' not found at location")
+  expect_false(file.exists(dest))
 })
 
 
@@ -130,8 +135,11 @@ test_that("Can find file from archive", {
   idx <- root$index()
 
   h <- idx$metadata[[1]]$files$hash
-  expect_equal(loc$fetch_file(h),
-               file.path(path, "archive", "data", ids[[1]], "data.rds"))
+  dest <- tempfile()
+  on.exit(unlink(dest), add = TRUE)
+  res <- loc$fetch_file(h, dest)
+  expect_identical(res, dest)
+  expect_identical(hash_file(dest), h)
 })
 
 
@@ -142,7 +150,9 @@ test_that("sensible error if file not found in archive", {
   outpack_init(path, use_file_store = FALSE)
   loc <- outpack_location_path$new(path)
   h <- "md5:c7be9a2c3cd8f71210d9097e128da316"
+  dest <- tempfile()
   expect_error(
-    loc$fetch_file(h),
+    loc$fetch_file(h, dest),
     "Hash 'md5:c7be9a2c3cd8f71210d9097e128da316' not found at location")
+  expect_false(file.exists(dest))
 })

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -1,0 +1,30 @@
+test_that("can run server", {
+  path <- tempfile()
+  root <- outpack_init(path, path_archive = "archive", use_file_store = TRUE)
+  server <- outpack_server(path)
+
+  client <- outpack_location_http$new(server$url(""))
+  cmp <- outpack_location_path$new(path)
+
+  expect_identical(client$list(),
+                   cmp$list())
+
+  ids <- create_random_packet_chain(path, 4)
+
+  ## There is a small issue in that the server is incorrectly
+  ## serialising the time; save it as fractional seconds since the
+  ## epoch (the same as the serialised format) so that this then
+  ## works. Be sure to keep the full acuracy though.
+  ## expect_identical(client$list(),
+  ##                  cmp$list())
+
+  expect_identical(client$metadata(ids),
+                   cmp$metadata(ids))
+
+  hash <- root$files$list()[[1]]
+  dest <- tempfile()
+  on.exit(unlink(dest), add = TRUE)
+  res <- client$fetch_file(hash, dest)
+  expect_identical(res, dest)
+  expect_identical(hash_file(dest), hash)
+})

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -1,30 +1,56 @@
-test_that("can run server", {
+describe("server integration tests", {
   path <- tempfile()
   root <- outpack_init(path, path_archive = "archive", use_file_store = TRUE)
   server <- outpack_server(path)
 
-  client <- outpack_location_http$new(server$url(""))
-  cmp <- outpack_location_path$new(path)
+  url <- server$url("")
+  client_http <- outpack_location_http$new(url)
+  client_path <- outpack_location_path$new(path)
 
-  expect_identical(client$list(),
-                   cmp$list())
+  it("returns sensible list data when empty", {
+    expect_identical(client_http$list(),
+                     client_path$list())
+  })
 
   ids <- create_random_packet_chain(path, 4)
 
-  ## There is a small issue in that the server is incorrectly
-  ## serialising the time; save it as fractional seconds since the
-  ## epoch (the same as the serialised format) so that this then
-  ## works. Be sure to keep the full acuracy though.
-  ## expect_identical(client$list(),
-  ##                  cmp$list())
+  it("returns sensible list data when non-empty", {
+    client_http <- outpack_location_http$new(url)
+    expect_identical(client_http$list(),
+                     client_path$list())
+  })
 
-  expect_identical(client$metadata(ids),
-                   cmp$metadata(ids))
+  it("returns compatible metadata", {
+    expect_identical(client_http$metadata(ids),
+                     client_path$metadata(ids))
+  })
 
-  hash <- root$files$list()[[1]]
-  dest <- tempfile()
-  on.exit(unlink(dest), add = TRUE)
-  res <- client$fetch_file(hash, dest)
-  expect_identical(res, dest)
-  expect_identical(hash_file(dest), hash)
+  it("throws compatible error on missing metadata", {
+    msg <- "Some packet ids not found: 'id-missing'"
+    expect_error(client_http$metadata("id-missing"), msg)
+    expect_error(client_path$metadata("id-missing"), msg)
+  })
+
+  it("can fetch files", {
+    hash <- root$files$list()[[1]]
+    dest <- tempfile()
+    on.exit(unlink(dest), add = TRUE)
+    res <- client_http$fetch_file(hash, dest)
+    expect_identical(res, dest)
+    expect_identical(hash_file(dest), hash)
+  })
+
+  it("throws compatible error on missing file", {
+    path1 <- tempfile()
+    path2 <- tempfile()
+    msg <- "Hash 'hash:abc123' not found at location"
+    err_http <- expect_error(
+      client_http$fetch_file("hash:abc123", path1),
+      msg)
+    err_path <- expect_error(
+      client_path$fetch_file("hash:abc123", path1),
+      msg)
+    expect_false(file.exists(path1))
+    expect_false(file.exists(path2))
+  })
 })

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -15,7 +15,6 @@ describe("server integration tests", {
   ids <- create_random_packet_chain(path, 4)
 
   it("returns sensible list data when non-empty", {
-    client_http <- outpack_location_http$new(url)
     expect_identical(client_http$list(),
                      client_path$list())
   })


### PR DESCRIPTION
This PR adds an http remote type, though does not wire it in fully.

There was a small tweak needed to the file store, in that we always need to copy the file in order to get eventually the same behaviour with the path based and http based locations. The store now provides a temporary path that is effectively guaranteed to be on the same file system so that moving works later.

The implementation of the location follows our usual pattern of a little http client, it's a bit boilerplaty but hopefully simple enough.

The testing is a bit of a nuisance because of avoiding the infinite dependency loop (outpack depends on outpack.server and v.v.). Eventually the server *might* be in another language, so I've chosen to have a little install dance in the test setup. We can later replace that with something that installs something into the path perhaps