### PR TITLE
Basic support for http locations

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -1,5 +1,6 @@
 local <- "local"
 orphan <- "orphan"
-location_reserved_name <- c("local", "orphan")
+location_reserved_name <- c(local, orphan)
+location_types <- c(local, orphan, "path", "http")
 ## NOTE: could read this from id.json
 re_id <- "^([0-9]{8}-[0-9]{6}-[[:xdigit:]]{8})$"

--- a/R/location.R
+++ b/R/location.R
@@ -69,18 +69,18 @@ outpack_location_add <- function(name, type, args, priority = 0, root = NULL) {
   }
   location_check_new_name(root, name)
 
-  ## We won't be necessarily be able to do this _generally_ but here,
-  ## let's confirm that we can read from the outpack archive at the
-  ## requested path; this will just fail but without providing the
-  ## user with anything actionable yet.
-  assert_scalar_character(path)
-  outpack_root_open(path, locate = FALSE)
+  loc <- new_location_entry(name, priority, type, args)
+  if (type == "path") {
+    ## We won't be necessarily be able to do this _generally_ but
+    ## here, let's confirm that we can read from the outpack archive
+    ## at the requested path; this will just fail but without
+    ## providing the user with anything actionable yet.
+    assert_scalar_character(loc$args[[1]]$path, name = "args$path")
+    outpack_root_open(loc$args[[1]]$path, locate = FALSE)
+  }
 
   config <- root$config
-
-  config$location <- rbind(
-    config$location,
-    new_location_entry(name, priority, type, args))
+  config$location <- rbind(config$location, loc)
   config$location <- config$location[
     order(config$location$priority, decreasing = TRUE), ]
   rownames(config$location) <- NULL
@@ -501,7 +501,7 @@ location_build_pull_plan <- function(packet_id, location_id, root) {
 
 
 new_location_entry <- function(name, priority, type, args) {
-  match_value(type, c("local", "path", "http"))
+  match_value(type, c("local", "path", "http", "orphan"))
   required <- NULL
   if (type == "path") {
     required <- "path"

--- a/inst/schema/config.json
+++ b/inst/schema/config.json
@@ -44,7 +44,7 @@
                         "type": "number"
                     },
                     "type": {
-                        "enum": ["local", "orphan", "path"]
+                        "enum": ["http", "local", "orphan", "path"]
                     }
                 },
                 "required": ["name", "id", "priority", "type"]

--- a/man/outpack_location_add.Rd
+++ b/man/outpack_location_add.Rd
@@ -4,14 +4,19 @@
 \alias{outpack_location_add}
 \title{Add a new location}
 \usage{
-outpack_location_add(name, path, priority = 0, root = NULL)
+outpack_location_add(name, type, args, priority = 0, root = NULL)
 }
 \arguments{
 \item{name}{The short name of the location to use.  Cannot be in
 use, and cannot be one of \code{local} or \code{orphan}}
 
-\item{path}{The path to the directory containing another outpack
-archive.}
+\item{type}{The type of location to add. Currently supported
+values are \code{path} (a location that exists elsewhere on the
+filesystem) and \code{http} (a location accessed over outpack's http
+API).}
+
+\item{args}{Arguments to the location driver. The arguments here
+will vary depending on the type used, see Details.}
 
 \item{priority}{The priority of the location. This is used when
 deciding where to pull packets from
@@ -32,10 +37,39 @@ Add a new location - a place where other packets might be found
 and pulled into your local archive.  Currently only file-based
 locations are supported.
 }
+\details{
+We currently support two types of locations - \code{path}, which points
+to an outpack archive accessible by path (e.g., on the same
+computer or on a mounted network share) and \code{http}, which requires
+that an outpack server is running at some url and uses an HTTP API
+to communicate. More types may be added later, and more
+configuration options to these location types will definitely be
+needed in future.
+
+Configuration options for different location types:
+
+\strong{Path locations}:
+\itemize{
+\item \code{path}: The path to the other archive root. This should
+generally be an absolute path, or the behaviour of outpack will
+be unreliable.
+}
+
+\strong{HTTP locations}:
+
+Accessing outpack over HTTP requires that an outpack server is
+running. The interface here is expected to change as we expand
+the API, but also as we move to support things like TLS and
+authentication.
+\itemize{
+\item \code{url}: The location of the server, including protocol, for
+example \verb{http://example.com:8080}
+}
+}
 \section{Warning}{
 
 
-The API here will change as we move to support different types of
+The API here may change as we move to support different types of
 locations.
 }
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -133,9 +133,9 @@ test_that("File store is not added if a hash cannot be resolved", {
                             root$metadata(id)$files$path))
   regex <- paste("Error adding file store:(.*)",
     "the following files were missing or corrupted: 'data.rds'")
-  expect_error(outpack_config_set(core.use_file_store = TRUE, root = root),
-               regex
-  )
+  expect_error(suppressMessages(
+    outpack_config_set(core.use_file_store = TRUE, root = root)),
+    regex)
   expect_false(root$config$core$use_file_store)
   expect_null(root$config$files)
 })
@@ -154,7 +154,7 @@ test_that("Files will be searched for by hash when adding file store", {
   fs::file_delete(file.path(path, "archive", "data", id,
                             root$metadata(id)$files$path))
 
-  outpack_config_set(core.use_file_store = TRUE, root = root)
+  suppressMessages(outpack_config_set(core.use_file_store = TRUE, root = root))
 
   expect_true(root$config$core$use_file_store)
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -92,7 +92,8 @@ test_that("Can add file_store", {
 
   id <- create_random_packet_chain(root$src, 3)
 
-  outpack_location_add("src", root$src$path, root = root$dst$path)
+  outpack_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst$path)
   outpack_location_pull_metadata(root = root$dst$path)
   outpack_location_pull_packet(id[["c"]], root = root$dst$path)
 
@@ -330,7 +331,8 @@ test_that("Enabling recursive pulls forces pulling missing packets", {
   expect_false(root$dst$config$core$require_complete_tree)
 
   id <- create_random_packet_chain(root$src, 3)
-  outpack_location_add("src", root$src$path, root = root$dst$path)
+  outpack_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst$path)
   outpack_location_pull_metadata(root = root$dst$path)
   outpack_location_pull_packet(id[["c"]], root = root$dst$path)
   expect_equal(root$dst$index()$unpacked$packet, id[["c"]])

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -89,7 +89,7 @@ test_that("Can rename a location", {
     root[[p]] <- outpack_init(file.path(path, p))
   }
 
-  outpack_location_add("b", root$b$path, root = root$a)
+  outpack_location_add("b", "path", list(path = root$b$path), root = root$a)
   expect_setequal(outpack_location_list(root = root$a), c("local", "b"))
 
   ids <- outpack_root_open(root$a, locate = TRUE)$config$location$id
@@ -112,8 +112,8 @@ test_that("Can't rename a location using an existent name", {
     root[[p]] <- outpack_init(file.path(path, p))
   }
 
-  outpack_location_add("b", root$b$path, root = root$a)
-  outpack_location_add("c", root$c$path, root = root$a)
+  outpack_location_add("b", "path", list(path = root$b$path), root = root$a)
+  outpack_location_add("c", "path", list(path = root$c$path), root = root$a)
 
   expect_error(outpack_location_rename("b", "c", root$a),
                "A location with name 'c' already exists")
@@ -157,8 +157,8 @@ test_that("Can remove a location", {
     root[[p]] <- outpack_init(file.path(path, p))
   }
 
-  outpack_location_add("b", root$b$path, root = root$a)
-  outpack_location_add("c", root$c$path, root = root$a)
+  outpack_location_add("b", "path", list(path = root$b$path), root = root$a)
+  outpack_location_add("c", "path", list(path = root$c$path), root = root$a)
   expect_setequal(outpack_location_list(root = root$a), c("local", "b", "c"))
 
   id <- create_random_packet(root$b)
@@ -190,9 +190,9 @@ test_that("Removing a location orphans packets only from that location", {
     root[[p]] <- outpack_init(file.path(path, p))
   }
 
-  outpack_location_add("c", root$c$path, root = root$b)
-  outpack_location_add("b", root$b$path, root = root$a)
-  outpack_location_add("c", root$c$path, root = root$a)
+  outpack_location_add("c", "path", list(path = root$c$path), root = root$b)
+  outpack_location_add("b", "path", list(path = root$b$path), root = root$a)
+  outpack_location_add("c", "path", list(path = root$c$path), root = root$a)
   expect_setequal(outpack_location_list(root = root$a), c("local", "b", "c"))
   expect_setequal(outpack_location_list(root = root$b), c("local", "c"))
 

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -828,3 +828,29 @@ test_that("if recursive pulls are required, pulls are recursive by default", {
   outpack_location_pull_packet(id[["c"]], recursive = NULL, root = root$deep)
   expect_setequal(root$deep$index()$unpacked$packet, id)
 })
+
+
+test_that("can't add unknown location type", {
+  path <- tempfile()
+  on.exit(unlink(path, recursive = TRUE))
+  root <- outpack_init(path)
+  expect_error(
+    outpack_location_add("other", "magic", list(arg = 1), root = path),
+    "type must be one of 'path', 'http'")
+})
+
+
+test_that("validate arguments to path locations", {
+  path <- tempfile()
+  on.exit(unlink(path, recursive = TRUE))
+  root <- outpack_init(path)
+  expect_error(
+    outpack_location_add("other", "path", list(root = "mypath"),
+                         root = path),
+    "Fields missing from args: 'path'")
+  expect_error(
+    outpack_location_add("other", "http", list(server = "example.com"),
+                         root = path),
+    "Fields missing from args: 'url'")
+  expect_equal(outpack_location_list(root = path), "local")
+})

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -16,10 +16,10 @@ test_that("Can add a location", {
     root[[p]] <- outpack_init(file.path(path, p))
   }
 
-  outpack_location_add("b", root$b$path, root = root$a)
+  outpack_location_add("b", "path", list(path = root$b$path), root = root$a)
   expect_setequal(outpack_location_list(root = root$a), c("local", "b"))
 
-  outpack_location_add("c", root$c$path, root = root$a)
+  outpack_location_add("c", "path", list(path = root$c$path), root = root$a)
   expect_setequal(outpack_location_list(root = root$a), c("local", "b", "c"))
 })
 
@@ -34,7 +34,8 @@ test_that("Can't add a location with reserved name", {
   upstream <- outpack_init(path_upstream)
 
   expect_error(
-    outpack_location_add("local", path_upstream, root = path),
+    outpack_location_add("local", "path", list(path = path_upstream),
+                         root = path),
     "Cannot add a location with reserved name 'local'")
 })
 
@@ -49,9 +50,11 @@ test_that("Can't add a location with existing name", {
     root[[p]] <- outpack_init(file.path(path, p))
   }
 
-  outpack_location_add("upstream", root$b$path, root = root$a)
+  outpack_location_add("upstream", "path", list(path = root$b$path),
+                       root = root$a)
   expect_error(
-    outpack_location_add("upstream", root$c$path, root = root$a),
+    outpack_location_add("upstream", "path", list(path = root$c$path),
+                         root = root$a),
     "A location with name 'upstream' already exists")
   expect_equal(outpack_location_list(root = root$a),
                c("local", "upstream"))
@@ -67,11 +70,11 @@ test_that("Require that (for now) locations must be paths", {
   other <- tempfile()
   on.exit(unlink(other, recursive = TRUE), add = TRUE)
   expect_error(
-    outpack_location_add("other", other, root = path),
+    outpack_location_add("other", "path", list(path = other), root = path),
     "Directory does not exist:")
   fs::dir_create(other)
   expect_error(
-    outpack_location_add("other", other, root = path),
+    outpack_location_add("other", "path", list(path = other), root = path),
     "'.+' does not look like an outpack root")
 })
 
@@ -262,7 +265,8 @@ test_that("can pull metadata from a file base location", {
   path_downstream <- file.path(tmp, "downstream")
   outpack_init(path_downstream, use_file_store = TRUE)
 
-  outpack_location_add("upstream", path_upstream, root = path_downstream)
+  outpack_location_add("upstream", "path", list(path = path_upstream),
+                       root = path_downstream)
   expect_equal(outpack_location_list(root = path_downstream),
                c("local", "upstream"))
 
@@ -293,7 +297,8 @@ test_that("can pull empty metadata", {
   path_downstream <- file.path(tmp, "downstream")
   outpack_init(path_downstream, use_file_store = TRUE)
 
-  outpack_location_add("upstream", path_upstream, root = path_downstream)
+  outpack_location_add("upstream", "path", list(path = path_upstream),
+                       root = path_downstream)
   outpack_location_pull_metadata("upstream", root = path_downstream)
 
   index <- outpack_root_open(path_downstream)$index()
@@ -312,7 +317,8 @@ test_that("pull metadata from subset of locations", {
   for (name in c("x", "y", "z")) {
     path[[name]] <- file.path(tmp, name)
     root[[name]] <- outpack_init(path[[name]], use_file_store = TRUE)
-    outpack_location_add(name, path[[name]], root = path$a)
+    outpack_location_add(name, "path", list(path = path[[name]]),
+                         root = path$a)
   }
 
   expect_equal(outpack_location_list(root = path$a),
@@ -385,10 +391,10 @@ test_that("Can pull metadata through chain of locations", {
   ## knowing directly about an earlier location
   ## > a -> b -> c -> d
   ## >      `--------/
-  outpack_location_add("a", root$a$path, root = root$b)
-  outpack_location_add("b", root$b$path, root = root$c)
-  outpack_location_add("b", root$b$path, root = root$d)
-  outpack_location_add("c", root$c$path, root = root$d)
+  outpack_location_add("a", "path", list(path = root$a$path), root = root$b)
+  outpack_location_add("b", "path", list(path = root$b$path), root = root$c)
+  outpack_location_add("b", "path", list(path = root$b$path), root = root$d)
+  outpack_location_add("c", "path", list(path = root$c$path), root = root$d)
 
   ## Create a packet and make sure it's in both b and c
   id1 <- create_random_packet(root$a)
@@ -428,7 +434,8 @@ test_that("can pull a packet from one location to another, using file store", {
   }
 
   id <- create_random_packet(root$src)
-  outpack_location_add("src", root$src$path, root = root$dst)
+  outpack_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst)
   outpack_location_pull_metadata(root = root$dst)
   outpack_location_pull_packet(id, root = root$dst)
 
@@ -452,7 +459,8 @@ test_that("can pull a packet from one location to another, archive only", {
   }
 
   id <- create_random_packet(root$src)
-  outpack_location_add("src", root$src$path, root = root$dst)
+  outpack_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst)
   outpack_location_pull_metadata(root = root$dst)
   outpack_location_pull_packet(id, root = root$dst)
 
@@ -485,7 +493,8 @@ test_that("detect and avoid modified files in source repository", {
     outpack_packet_end()
   }
 
-  outpack_location_add("src", root$src$path, root = root$dst)
+  outpack_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst)
   outpack_location_pull_metadata(root = root$dst)
 
   ## Corrupt the file in the first id by truncating it:
@@ -514,7 +523,8 @@ test_that("Do not unpack a packet twice", {
   }
 
   id <- create_random_packet(root$src)
-  outpack_location_add("src", root$src$path, root = root$dst)
+  outpack_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst)
   outpack_location_pull_metadata(root = root$dst)
   outpack_location_pull_packet(id, "src", root = root$dst)
 
@@ -535,7 +545,8 @@ test_that("Sensible error if packet not known", {
   }
 
   id <- create_random_packet(root$src)
-  outpack_location_add("src", root$src$path, root = root$dst)
+  outpack_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst)
   expect_error(
     outpack_location_pull_packet(id, "src", root = root$dst),
     "Failed to find packet at location 'src': '.+'")
@@ -574,7 +585,8 @@ test_that("Can pull a tree recursively", {
   outpack_packet_run("script.R")
   outpack_packet_end()
 
-  outpack_location_add("src", root$src$path, root = root$dst)
+  outpack_location_add("src", "path", list(path = root$src$path),
+                       root = root$dst)
   outpack_location_pull_metadata(root = root$dst)
   expect_equal(
     outpack_location_pull_packet(id$c, "src", recursive = TRUE,
@@ -604,8 +616,10 @@ test_that("Can add locations with different priorities", {
     root[[p]] <- outpack_init(file.path(path, p))
   }
 
-  outpack_location_add("b", root$b$path, priority = 5, root = root$a)
-  outpack_location_add("c", root$b$path, priority = 10, root = root$a)
+  outpack_location_add("b", "path", list(path = root$b$path), priority = 5,
+                       root = root$a)
+  outpack_location_add("c", "path", list(path = root$b$path), priority = 10,
+                       root = root$a)
   expect_equal(root$a$config$location$name, c("c", "b", "local"))
   expect_equal(root$a$config$location$priority, c(10, 5, 0))
 
@@ -627,8 +641,8 @@ test_that("Can resolve locations", {
 
   priority <- c(a = -5, b = 20, c = 10, d = 15)
   for (i in names(priority)) {
-    outpack_location_add(i, root[[i]]$path, priority = priority[[i]],
-                         root = root$dst)
+    outpack_location_add(i, "path", list(path = root[[i]]$path),
+                         priority = priority[[i]], root = root$dst)
   }
 
   location_id <- set_names(
@@ -707,21 +721,21 @@ test_that("Can filter locations", {
   }
 
   ids_a <- vcapply(1:3, function(i) create_random_packet(root$a$path))
-  outpack_location_add("a", root$a$path, root = root$b)
+  outpack_location_add("a", "path", list(path = root$a$path), root = root$b)
   outpack_location_pull_metadata(root = root$b)
   ids_b <- c(ids_a,
              vcapply(1:3, function(i) create_random_packet(root$b$path)))
   ids_c <- vcapply(1:3, function(i) create_random_packet(root$c$path))
-  outpack_location_add("a", root$a$path, root = root$d)
-  outpack_location_add("c", root$c$path, root = root$d)
+  outpack_location_add("a", "path", list(path = root$a$path), root = root$d)
+  outpack_location_add("c", "path", list(path = root$c$path), root = root$d)
   outpack_location_pull_metadata(root = root$d)
   ids_d <- c(ids_c,
              vcapply(1:3, function(i) create_random_packet(root$d$path)))
 
   priority <- c(a = 20, b = 15, c = 10, d = 5)
   for (i in names(priority)) {
-    outpack_location_add(i, root[[i]]$path, priority = priority[[i]],
-                         root = root$dst)
+    outpack_location_add(i, "path", list(path = root[[i]]$path),
+                         priority = priority[[i]], root = root$dst)
   }
   outpack_location_pull_metadata(root = root$dst)
 
@@ -804,7 +818,7 @@ test_that("if recursive pulls are required, pulls are recursive by default", {
   id <- create_random_packet_chain(root$src, 3)
 
   for (r in root[c("shallow", "deep")]) {
-    outpack_location_add("src", root$src$path, root = r)
+    outpack_location_add("src", "path", list(path = root$src$path), root = r)
     outpack_location_pull_metadata(root = r)
   }
 

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -171,7 +171,8 @@ test_that("location based queries", {
   for (name in c("x", "y", "z")) {
     path[[name]] <- file.path(tmp, name)
     root[[name]] <- outpack_init(path[[name]], use_file_store = TRUE)
-    outpack_location_add(name, path[[name]], root = path$a)
+    outpack_location_add(name, "path", list(path = path[[name]]),
+                         root = path$a)
   }
 
   ids <- list()
@@ -274,7 +275,8 @@ test_that("Can filter query to packets that are locally available (unpacked)", {
   for (name in c("x", "y", "z")) {
     path[[name]] <- file.path(tmp, name)
     root[[name]] <- outpack_init(path[[name]], use_file_store = TRUE)
-    outpack_location_add(name, path[[name]], root = path$a)
+    outpack_location_add(name, "path", list(path = path[[name]]),
+                         root = path$a)
   }
 
   ids <- list()

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -68,8 +68,7 @@ describe("http location integration tests", {
     on.exit(unlink(tmp, recursive = TRUE))
     path_downstream <- file.path(tmp, "downstream")
     outpack_init(path_downstream, use_file_store = TRUE)
-    expect_equal(names(outpack_root_open(path_downstream)$index()$metadata),
-                 character())
+    expect_null(names(outpack_root_open(path_downstream)$index()$metadata))
     outpack_location_add("upstream", "http", list(url = url),
                          root = path_downstream)
     expect_equal(outpack_location_list(root = path_downstream),


### PR DESCRIPTION
This PR builds on #28, and actually wires the location right through. There's still no support for auth, and probably won't be for a bit.

I've set up some sort of vaguely extendable configuration for the two remote types (path and http), and set `outpack_location_add` up to pass these through which causes a bit of churn in the diff.