### PR TITLE
mrc-3038 make casing consistent

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -188,7 +188,7 @@ config_new <- function(path_archive, use_file_store, require_complete_tree) {
 
 
 config_serialise <- function(config, path) {
-  config$schema_version <- scalar(config$schema_version) # nolint
+  config$schema_version <- scalar(config$schema_version)
   config$core <- lapply(config$core, scalar)
 
   prepare_location <- function(loc) {

--- a/R/config.R
+++ b/R/config.R
@@ -177,7 +177,7 @@ config_new <- function(path_archive, use_file_store, require_complete_tree) {
   hash_algorithm <- "sha256"
 
   list(
-    schemaVersion = outpack_schema_version(),
+    schema_version = outpack_schema_version(),
     core = list(
       path_archive = path_archive,
       use_file_store = use_file_store,
@@ -188,7 +188,7 @@ config_new <- function(path_archive, use_file_store, require_complete_tree) {
 
 
 config_serialise <- function(config, path) {
-  config$schemaVersion <- scalar(config$schemaVersion) # nolint
+  config$schema_version <- scalar(config$schema_version) # nolint
   config$core <- lapply(config$core, scalar)
 
   prepare_location <- function(loc) {

--- a/R/insert.R
+++ b/R/insert.R
@@ -58,7 +58,7 @@ outpack_insert_packet <- function(path, json, root = NULL) {
 
 
 mark_packet_known <- function(packet_id, location_id, hash, time, root) {
-  dat <- list(schemaVersion = scalar(outpack_schema_version()),
+  dat <- list(schema_version = scalar(outpack_schema_version()),
               packet = scalar(packet_id),
               time = scalar(time_to_num(time)),
               hash = scalar(hash))
@@ -69,7 +69,7 @@ mark_packet_known <- function(packet_id, location_id, hash, time, root) {
 
 
 mark_packet_unpacked <- function(packet_id, location_id, root) {
-  dat <- list(schemaVersion = scalar(outpack_schema_version()),
+  dat <- list(schema_version = scalar(outpack_schema_version()),
               packet = scalar(packet_id),
               time = scalar(time_to_num()),
               location = scalar(location_id))

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -91,7 +91,7 @@ outpack_metadata_create <- function(path, name, id, time, files,
                         vcapply(custom, "[[", "application"))
   }
 
-  ret <- list(schemaVersion = scalar(outpack_schema_version()),
+  ret <- list(schema_version = scalar(outpack_schema_version()),
               name = scalar(name),
               id = scalar(id),
               time = time,

--- a/inst/schema/config.json
+++ b/inst/schema/config.json
@@ -6,7 +6,7 @@
 
     "type": "object",
     "properties": {
-        "schemaVersion": {
+        "schema_version": {
             "description": "Schema version, used to manage migrations",
             "type": "string",
             "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
@@ -52,5 +52,5 @@
         }
     },
 
-    "required": ["schemaVersion", "core"]
+    "required": ["schema_version", "core"]
 }

--- a/inst/schema/location.json
+++ b/inst/schema/location.json
@@ -6,7 +6,7 @@
 
     "type": "object",
     "properties": {
-        "schemaVersion": {
+        "schema_version": {
             "description": "Schema version, used to manage migrations",
             "type": "string",
             "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
@@ -25,5 +25,5 @@
             "$ref": "hash.json"
         }
     },
-    "required": ["schemaVersion", "packet", "time", "hash"]
+    "required": ["schema_version", "packet", "time", "hash"]
 }

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -6,7 +6,7 @@
 
     "type": "object",
     "properties": {
-        "schemaVersion": {
+        "schema_version": {
             "description": "Schema version, used to manage migrations",
             "type": "string",
             "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
@@ -110,5 +110,5 @@
             "description": "Information about the session; necessarily engine-specific format but in a standardised location"
         }
     },
-    "required": ["schemaVersion", "id", "name", "time", "files", "depends", "script", "custom", "session"]
+    "required": ["schema_version", "id", "name", "time", "files", "depends", "script", "custom", "session"]
 }

--- a/inst/schema/unpacked.json
+++ b/inst/schema/unpacked.json
@@ -6,7 +6,7 @@
 
     "type": "object",
     "properties": {
-        "schemaVersion": {
+        "schema_version": {
             "description": "Schema version, used to manage migrations",
             "type": "string",
             "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
@@ -26,5 +26,5 @@
             "$ref": "locationId.json"
         }
     },
-    "required": ["schemaVersion", "packet", "time", "location"]
+    "required": ["schema_version", "packet", "time", "location"]
 }

--- a/tests/testthat/test-packet.R
+++ b/tests/testthat/test-packet.R
@@ -54,10 +54,10 @@ test_that("Can run a basic packet", {
 
   expect_setequal(
     names(meta),
-    c("schemaVersion", "name", "id", "time", "parameters", "files",
+    c("schema_version", "name", "id", "time", "parameters", "files",
       "depends", "script", "session", "custom", "hash"))
 
-  expect_equal(meta$schemaVersion, outpack_schema_version())
+  expect_equal(meta$schema_version, outpack_schema_version())
   expect_equal(meta$name, "example")
   expect_equal(meta$id, id)
   expect_null(meta$parameters)

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -144,5 +144,5 @@ test_that("Can read full metadata via root", {
   expect_identical(d1[names(d2)], d2)
   extra <- setdiff(names(d1), names(d2))
   expect_equal(d1$script, list())
-  expect_equal(d1$schemaVersion, outpack_schema_version())
+  expect_equal(d1$schema_version, outpack_schema_version())
 })


### PR DESCRIPTION
The ticket here was to make all the json properties camel case. But this means either:
1. Using a mix of camel case and snake case properties within the code, confusing and hard to get right
2. Writing a serialiser that serialises the snake case R properties into camel case at the point of writing out json and a deserialiser for when json is read back in. It'd be better if this lived within jsonlite though, questionable whether worth doing it within outpack...