### PR TITLE
Allow explicitly passing in a packet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/packet.R
+++ b/R/packet.R
@@ -419,7 +419,7 @@ check_current_packet <- function(packet) {
       stop("No currently active packet")
     }
   } else {
-    assert_is(packet, "packet")
+    assert_is(packet, "outpack_packet")
     if (isTRUE(packet$complete)) {
       stop(sprintf("Packet '%s' is complete", packet$id))
     }

--- a/R/packet.R
+++ b/R/packet.R
@@ -3,6 +3,13 @@
 ##' the current packet (`outpack_packet_use_dependency`,
 ##' `outpack_packet_run`)
 ##'
+##' There are two ways of using these functions - normally you call
+##' `outpack_packet_start`, which registers an "active" packet,
+##' following this all other functions (e.g., `outpack_packet_run`)
+##' use this active packet. The other approach is to take the return
+##' value from `outpack_packet_start` and pass that through as the
+##' `packet` argument to any other function.
+##'
 ##' @title Start, interact with, and end a packet build
 ##'
 ##' @param path Path to the build / output directory.
@@ -13,25 +20,32 @@
 ##'   names must be unique, and the values must all be non-NA scalar
 ##'   atomics (logical, integer, numeric, character)
 ##'
+##' @param local Logical, indicating if this should be considered a
+##'   "local" packet and not set as the default for other packet
+##'   functions. If `TRUE`, then you must explicitly pass the packet
+##'   (the return value from `outpack_packet_start`) into each of the
+##'   other packet functions (e.g, `outpack_packet_run` and
+##'   `outpack_packet_end`)
+##'
 ##' @param id Optionally, an outpack id via [outpack::outpack_id]. If
 ##'   not given a new id will be generated.
 ##'
 ##' @param root The outpack root. Will be searched for from the
 ##'   current directory if not given.
 ##'
-##' @return Invisibly, a copy of the packet data
+##' @return Invisibly, a copy of the packet data; this can be passed
+##'   as the `packet` argument.
+##'
 ##' @rdname outpack_packet
 ##' @export
 outpack_packet_start <- function(path, name, parameters = NULL, id = NULL,
-                                 root = NULL) {
+                                 local = FALSE, root = NULL) {
   root <- outpack_root_open(root, locate = TRUE)
-  if (!is.null(current$packet)) {
+  assert_scalar_logical(local)
+  if (!is.null(current$packet) && !local) {
     ## * Could make this root specific?
-    ## * Could make this path specific?
-    ## * Could use a stack?
-    ## * Could automatically exit?
-    ## * Could be fine if name/id match
-    stop("Already a current packet - call outpack_packet_cancel()")
+    stop(paste("Already a current packet - call outpack_packet_cancel()",
+               "or use local = TRUE for an isolated packet"))
   }
 
   assert_scalar_character(name)
@@ -49,41 +63,47 @@ outpack_packet_start <- function(path, name, parameters = NULL, id = NULL,
   ## LOGGING: name / id / path, start time, parameters
   ##
   ## We log these all in orderly and that's super useful
-  current$packet <- list(
-    name = name,
-    id = id,
-    path = path,
-    parameters = parameters,
-    files = list(),
-    time = time,
-    root = root)
+  packet <- structure(
+    list2env(
+      list(
+        name = name,
+        id = id,
+        path = path,
+        parameters = parameters,
+        files = list(),
+        time = time,
+        root = root),
+      parent = emptyenv()),
+    class = "outpack_packet")
 
-  invisible(current$packet)
+  if (!local) {
+    current$packet <- packet
+  }
+
+  invisible(packet)
 }
 
 
 ##' @export
 ##' @rdname outpack_packet
-outpack_packet_cancel <- function() {
-  p <- outpack_packet_current()
-  outpack_packet_clear()
+##' @param packet Optionally, an explicitly-passed packet; see Details
+outpack_packet_cancel <- function(packet = NULL) {
+  p <- check_current_packet(packet)
+  outpack_packet_finish(p)
 }
 
 
 ##' @export
 ##' @rdname outpack_packet
 outpack_packet_current <- function() {
-  if (is.null(current$packet)) {
-    stop("No current packet")
-  }
-  current$packet
+  check_current_packet(NULL)
 }
 
 
 ##' @export
 ##' @rdname outpack_packet
-outpack_packet_end <- function() {
-  p <- outpack_packet_current()
+outpack_packet_end <- function(packet = NULL) {
+  p <- check_current_packet(packet)
   p$time$end <- Sys.time()
   hash_algorithm <- p$root$config$core$hash_algorithm
   json <- outpack_metadata_create(p$path, p$name, p$id, p$time,
@@ -97,7 +117,7 @@ outpack_packet_end <- function() {
                                   file_ignore = p$files$ignored,
                                   hash_algorithm = hash_algorithm)
   outpack_insert_packet(p$path, json, p$root)
-  outpack_packet_clear()
+  outpack_packet_finish(p)
 }
 
 
@@ -113,8 +133,9 @@ outpack_packet_end <- function() {
 ##' @param echo Print the result of running the R code to the
 ##'   console. This may be difficult to suppress in some context, as
 ##'   it comes directly from R's [source] function.
-outpack_packet_run <- function(script, envir = .GlobalEnv, echo = FALSE) {
-  p <- outpack_packet_current()
+outpack_packet_run <- function(script, envir = .GlobalEnv, echo = FALSE,
+                               packet = NULL) {
+  p <- check_current_packet(packet)
   assert_relative_path(script, no_dots = TRUE)
   assert_file_exists(script, p$path, "Script")
 
@@ -145,7 +166,6 @@ outpack_packet_run <- function(script, envir = .GlobalEnv, echo = FALSE) {
   })
 
   p$script <- c(p$script, script)
-  current$packet <- p
 
   ## What is a good return value here?
   invisible()
@@ -160,8 +180,8 @@ outpack_packet_run <- function(script, envir = .GlobalEnv, echo = FALSE) {
 ##' @param files A named character vector of files; the name
 ##'   corresponds to the name within the current packet, while the
 ##'   value corresponds to the name within the upstream packet
-outpack_packet_use_dependency <- function(id, files) {
-  p <- outpack_packet_current()
+outpack_packet_use_dependency <- function(id, files, packet = NULL) {
+  p <- check_current_packet(packet)
   root <- p$root
 
   ## TODO: currently no capacity here for *querying* to find the id
@@ -190,7 +210,7 @@ outpack_packet_use_dependency <- function(id, files) {
 
   depends <- list(packet = id,
                   files = data_frame(here = names(files), there = src))
-  current$packet$depends <- c(p$depends, list(depends))
+  p$depends <- c(p$depends, list(depends))
 
   invisible()
 }
@@ -262,8 +282,9 @@ outpack_packet_use_dependency <- function(id, files) {
 ##'   `outpack.schema_validate` is `TRUE`, as for the main schema
 ##'   validation.  Will be passed to [jsonvalidate::json_schema], so
 ##'   can be a string containing the schema or a path to the schema.
-outpack_packet_add_custom <- function(application, data, schema = NULL) {
-  p <- outpack_packet_current()
+outpack_packet_add_custom <- function(application, data, schema = NULL,
+                                      packet = NULL) {
+  p <- check_current_packet(packet)
 
   assert_scalar_character(application)
   assert_scalar_character(data)
@@ -291,7 +312,7 @@ outpack_packet_add_custom <- function(application, data, schema = NULL) {
   }
 
   custom <- list(application = application, data = data)
-  current$packet$custom <- c(p$custom, list(custom))
+  p$custom <- c(p$custom, list(custom))
   invisible()
 }
 
@@ -318,9 +339,9 @@ outpack_packet_add_custom <- function(application, data, schema = NULL) {
 ##' @rdname outpack_packet_file
 ##'
 ##' @export
-outpack_packet_file_mark <- function(files, status) {
+outpack_packet_file_mark <- function(files, status, packet = NULL) {
   status <- match_value(status, c("immutable", "ignored"))
-  p <- outpack_packet_current()
+  p <- check_current_packet(packet)
 
   assert_relative_path(files, no_dots = TRUE)
   assert_file_exists(files, p$path)
@@ -341,7 +362,7 @@ outpack_packet_file_mark <- function(files, status) {
       value <- value[!(names(value) %in% names(p$files))]
     }
 
-    current$packet$files$immutable <- c(p$files$immutable, value)
+    p$files$immutable <- c(p$files$immutable, value)
   } else if (status == "ignored") {
     if (any(files %in% names(p$files$immutable))) {
       stop(sprintf("Cannot mark immutable files as ignored: %s",
@@ -349,7 +370,7 @@ outpack_packet_file_mark <- function(files, status) {
                          collapse = ", ")))
     }
 
-    current$packet$files$ignored <- union(p$files$ignored, files)
+    p$files$ignored <- union(p$files$ignored, files)
   }
   invisible()
 }
@@ -357,8 +378,8 @@ outpack_packet_file_mark <- function(files, status) {
 
 ##' @export
 ##' @rdname outpack_packet_file
-outpack_packet_file_list <- function() {
-  p <- outpack_packet_current()
+outpack_packet_file_list <- function(packet = NULL) {
+  p <- check_current_packet(packet)
   files <- with_dir(p$path,
                     dir(all.files = TRUE, recursive = TRUE, no.. = TRUE))
   status <- rep("unknown", length(files))
@@ -368,8 +389,42 @@ outpack_packet_file_list <- function() {
 }
 
 
+
+## Mostly used in tests as an unconditional "remove any packet with no
+## chance of failure" (vs outpack_packet_finish, which does a more
+## careful tidyup)
 outpack_packet_clear <- function() {
-  current$packet <- NULL
+  if (!is.null(current$packet)) {
+    current$packet$complete <- TRUE
+    current$packet <- NULL
+  }
+}
+
+
+outpack_packet_finish <- function(packet) {
+  packet$complete <- TRUE
+  if (identical(packet, current$packet)) {
+    current$packet <- NULL
+  }
+}
+
+
+## This is used in each of the functions that accept either 'packet'
+## as an argument and which will fall back onto the global active
+## packet.
+check_current_packet <- function(packet) {
+  if (is.null(packet)) {
+    packet <- current$packet
+    if (is.null(packet)) {
+      stop("No currently active packet")
+    }
+  } else {
+    assert_is(packet, "packet")
+    if (isTRUE(packet$complete)) {
+      stop(sprintf("Packet '%s' is complete", packet$id))
+    }
+  }
+  packet
 }
 
 

--- a/R/packet.R
+++ b/R/packet.R
@@ -330,6 +330,9 @@ outpack_packet_add_custom <- function(application, data, schema = NULL,
 ##' @param status A status to mark the file with. Must be "immutable"
 ##'   or "ignored"
 ##'
+##' @param packet Optionally, an explicitly-passed packet; see
+##'   [outpack::outpack_packet_start()] for details.
+##'
 ##' @return Depending on function
 ##'
 ##' * `outpack_packet_file_mark` returns nothing

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -10,19 +10,26 @@
 \alias{outpack_packet_add_custom}
 \title{Start, interact with, and end a packet build}
 \usage{
-outpack_packet_start(path, name, parameters = NULL, id = NULL, root = NULL)
+outpack_packet_start(
+  path,
+  name,
+  parameters = NULL,
+  id = NULL,
+  local = FALSE,
+  root = NULL
+)
 
-outpack_packet_cancel()
+outpack_packet_cancel(packet = NULL)
 
 outpack_packet_current()
 
-outpack_packet_end()
+outpack_packet_end(packet = NULL)
 
-outpack_packet_run(script, envir = .GlobalEnv, echo = FALSE)
+outpack_packet_run(script, envir = .GlobalEnv, echo = FALSE, packet = NULL)
 
-outpack_packet_use_dependency(id, files)
+outpack_packet_use_dependency(id, files, packet = NULL)
 
-outpack_packet_add_custom(application, data, schema = NULL)
+outpack_packet_add_custom(application, data, schema = NULL, packet = NULL)
 }
 \arguments{
 \item{path}{Path to the build / output directory.}
@@ -35,8 +42,17 @@ atomics (logical, integer, numeric, character)}
 
 \item{id}{The id of an existing packet to use files from}
 
+\item{local}{Logical, indicating if this should be considered a
+"local" packet and not set as the default for other packet
+functions. If \code{TRUE}, then you must explicitly pass the packet
+(the return value from \code{outpack_packet_start}) into each of the
+other packet functions (e.g, \code{outpack_packet_run} and
+\code{outpack_packet_end})}
+
 \item{root}{The outpack root. Will be searched for from the
 current directory if not given.}
+
+\item{packet}{Optionally, an explicitly-passed packet; see Details}
 
 \item{script}{Path to the script within the packet directory (a
 relative path).  This function can be safely called multiple
@@ -65,13 +81,22 @@ validation.  Will be passed to \link[jsonvalidate:json_schema]{jsonvalidate::jso
 can be a string containing the schema or a path to the schema.}
 }
 \value{
-Invisibly, a copy of the packet data
+Invisibly, a copy of the packet data; this can be passed
+as the \code{packet} argument.
 }
 \description{
 Start a packet build (\code{outpack_packet_start}), end one
 (\code{outpack_packet_cancel}, \code{outpack_packet_end}) and interact with
 the current packet (\code{outpack_packet_use_dependency},
 \code{outpack_packet_run})
+}
+\details{
+There are two ways of using these functions - normally you call
+\code{outpack_packet_start}, which registers an "active" packet,
+following this all other functions (e.g., \code{outpack_packet_run})
+use this active packet. The other approach is to take the return
+value from \code{outpack_packet_start} and pass that through as the
+\code{packet} argument to any other function.
 }
 \section{Custom metadata}{
 

--- a/man/outpack_packet_file.Rd
+++ b/man/outpack_packet_file.Rd
@@ -14,6 +14,9 @@ outpack_packet_file_list(packet = NULL)
 
 \item{status}{A status to mark the file with. Must be "immutable"
 or "ignored"}
+
+\item{packet}{Optionally, an explicitly-passed packet; see
+\code{\link[=outpack_packet_start]{outpack_packet_start()}} for details.}
 }
 \value{
 Depending on function

--- a/man/outpack_packet_file.Rd
+++ b/man/outpack_packet_file.Rd
@@ -5,9 +5,9 @@
 \alias{outpack_packet_file_list}
 \title{Mark files during packet run}
 \usage{
-outpack_packet_file_mark(files, status)
+outpack_packet_file_mark(files, status, packet = NULL)
 
-outpack_packet_file_list()
+outpack_packet_file_list(packet = NULL)
 }
 \arguments{
 \item{files}{A character vector of relative paths}

--- a/tests/testthat/test-packet.R
+++ b/tests/testthat/test-packet.R
@@ -23,12 +23,17 @@ test_that("Can run a basic packet", {
   root <- outpack_init(path, path_archive = "archive", use_file_store = TRUE)
 
   p <- outpack_packet_start(path_src, "example", root = root)
+  expect_s3_class(p, "outpack_packet")
+  expect_null(p$complete)
+  expect_identical(p, current$packet)
 
   outpack_packet_run("script.R")
   expect_true(file.exists(file.path(path_src, "myplot.png")))
   expect_equal(outpack_packet_current()$script, "script.R")
 
   outpack_packet_end()
+  expect_true(p$complete)
+  expect_null(current$p)
 
   index <- root$index()
   expect_length(index$metadata, 1)
@@ -167,7 +172,7 @@ test_that("Can't use a nonexistant running packet", {
   outpack_packet_clear()
   expect_error(
     outpack_packet_current(),
-    "No current packet")
+    "No currently active packet")
 })
 
 

--- a/tests/testthat/test-packet.R
+++ b/tests/testthat/test-packet.R
@@ -632,3 +632,30 @@ test_that("can detect device imbalance", {
   ## Handler has fixed the stack for us:
   expect_equal(stack, dev.list())
 })
+
+
+test_that("Validate a packet", {
+  on.exit(outpack_packet_clear(), add = TRUE)
+  root <- create_temporary_root(path_archive = "archive", use_file_store = TRUE)
+  path_src <- create_temporary_simple_src()
+
+  p1 <- outpack_packet_start(path_src, "example", local = TRUE, root = root)
+  expect_null(current$packet)
+  p2 <- outpack_packet_start(path_src, "example", root = root)
+  expect_false(identical(p1, p2))
+  expect_identical(p2, current$packet)
+
+  expect_identical(check_current_packet(NULL), p2)
+  expect_identical(check_current_packet(p1), p1)
+  expect_identical(check_current_packet(p2), p2)
+
+  outpack_packet_finish(p1)
+  outpack_packet_finish(p2)
+
+  expect_error(check_current_packet(NULL),
+               "No currently active packet")
+  expect_error(check_current_packet(p1),
+               "Packet '.+' is complete")
+  expect_error(check_current_packet(p2),
+               "Packet '.+' is complete")
+})

--- a/tests/testthat/test-packet.R
+++ b/tests/testthat/test-packet.R
@@ -659,3 +659,20 @@ test_that("Validate a packet", {
   expect_error(check_current_packet(p2),
                "Packet '.+' is complete")
 })
+
+
+test_that("run basic report with explicit packet", {
+  on.exit(outpack_packet_clear(), add = TRUE)
+  root <- create_temporary_root(path_archive = "archive", use_file_store = TRUE)
+  path_src <- create_temporary_simple_src()
+
+  inputs <- c("data.csv", "script.R")
+  env <- new.env()
+
+  p <- outpack_packet_start(path_src, "example", local = TRUE, root = root)
+  outpack_packet_run("script.R", env, echo = FALSE, packet = p)
+  outpack_packet_end(packet = p)
+
+  expect_equal(names(root$index()$metadata), p$id)
+  expect_true(p$complete)
+})


### PR DESCRIPTION
This is something that we're going to need for the "develop mode" in orderly - it's quite possible that idea of a global packet is not a good one really and this might become the only way of running things.

The idea here is that we have `outpack_packet_start` return a packet object; this can then be passed in to any of the `outpack_packet_*` functions (e.g., `outpack_packet_use_dependency`). If `NULL` then we fall back on the global packet.

In order to make updates to the packet work as expected, I've changed the packet data type from a list to an environment, essentially making the packet data mutable. This is *probably* the original reason for using a global object?