### PR TITLE
mrc-4079: Add name argument to outpack_search

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -23,3 +23,5 @@
 \.*gcov$
 ^TODO\.md$
 ^benchmarks$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -10,7 +10,7 @@ Description: Create a portable package of output from a computational
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 URL: https://github.com/mrc-ide/outpack
 BugReports: https://github.com/mrc-ide/outpack/issues
 Imports:

--- a/man/outpack_query.Rd
+++ b/man/outpack_query.Rd
@@ -8,6 +8,7 @@ outpack_query(
   expr,
   pars = NULL,
   scope = NULL,
+  name = NULL,
   require_unpacked = FALSE,
   root = NULL
 )
@@ -20,6 +21,10 @@ into the query (using the \verb{this:} prefix)}
 
 \item{scope}{Optionally, a scope query to limit the packets
 searched by \code{pars}}
+
+\item{name}{Optionally, the name of the packet to scope the query on. This
+will be intersected with \code{scope} arg and is a shorthand way of running
+\code{scope = list(name = "name")}}
 
 \item{require_unpacked}{Logical, indicating if we should require
 that the packets are unpacked. If \code{FALSE} (the default) we

--- a/outpack.Rproj
+++ b/outpack.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -336,3 +336,21 @@ test_that("correct behaviour with empty queries", {
   expect_equal(outpack_query(quote(name == "data"), root = root),
                character(0))
 })
+
+test_that("named queries", {
+  tmp <- temp_file()
+  root <- outpack_init(tmp, use_file_store = TRUE)
+
+  x1 <- create_random_packet(tmp, "x", list(a = 1))
+  x2 <- create_random_packet(tmp, "x", list(a = 2))
+  y1 <- create_random_packet(tmp, "y", list(a = 1))
+  y2 <- create_random_packet(tmp, "y", list(a = 2))
+
+  expect_equal(
+    outpack_query(quote(latest()), name = "x", root = root),
+    x2)
+  expect_equal(
+    outpack_query(quote(latest()), scope = quote(parameter:a == 1),
+                  name = "x", root = root),
+    x1)
+})

--- a/vignettes/query.Rmd
+++ b/vignettes/query.Rmd
@@ -69,7 +69,7 @@ Scoping queries can be used to reduce the set of packets that are searched over.
 For example, the query
 
 ```r
-outpack_query(quote(parameter:x == 1), quote(name == "data"))`
+outpack_query(quote(parameter:x == 1), scope = quote(name == "data"))
 ```
 
 is equivalent to
@@ -81,6 +81,20 @@ outpack_query(quote(parameter:x == 1 && name == "data"))
 except that in the former we only check the parameter values of packets called "data".
 
 Orderly will use this functionality when resolving dependencies.
+
+### Scoping on name
+
+Very often users will want to scope by name so instead of passing `scope` argument there is a shorthand `name` argument for usability.
+
+```r
+outpack_query(quote(parameter:x == 1), name = "data")
+```
+
+Which is the equivalent of
+
+```r
+outpack_query(quote(parameter:x == 1), scope = quote(name == "data"))
+```
 
 ## Possible future queries and interface improvements
 


### PR DESCRIPTION
This PR will
* Add a `name` argument to `outpack_search` which is a shorthand for setting `scope = quote(name == "x")`. The `name` arg gets combined with the `scope`.

Note
* Should we check if both the user has passed a `name` and the `scope` contains a `name` then error if they are not the same? At the moment this will return no packets
* I was also going to look at changing the `scope` arg to take a list e.g. `scope = list(name = "value", "parameter:a" = 1)` but I'm not sure how we'd make this work with `at_location("x", "y")` so I have left this