### PR TITLE
Simplify scope in outpack_query so we need to track fewer packet indices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.2.3
+Version: 0.2.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/query.R
+++ b/R/query.R
@@ -53,7 +53,7 @@ outpack_query <- function(expr, pars = NULL, scope = NULL,
   }
 
   if (!is.null(scope)) {
-    expr_parsed <- query_parse_add_scope(expr_parsed, scope)
+    expr_parsed <- query_parse_add_scope(expr, expr_parsed, scope)
   }
 
   validate_parameters(pars)
@@ -159,7 +159,7 @@ query_parse_at_location <- function(expr, context, subquery_env) {
 }
 
 
-query_parse_add_scope <- function(expr_parsed, scope) {
+query_parse_add_scope <- function(expr, expr_parsed, scope) {
   if (!is.language(scope)) {
     stop("Invalid input for `scope`, it must be a language expression.")
   }

--- a/R/query_index.R
+++ b/R/query_index.R
@@ -8,7 +8,7 @@ query_index <- R6::R6Class(
   cloneable = FALSE,
 
   public = list(
-    #' @field index The active index
+    #' @field index The packet index
     index = NULL,
     #' @field depends Named list of data frames. Names are packet ids, values
     #'   are packets dependend on by this packet id (i.e. its parents).
@@ -26,8 +26,6 @@ query_index <- R6::R6Class(
     initialize = function(root, index, depends) {
       self$root <- root
       self$index <- index
-      private$index_unfiltered <- self$index
-      private$index_scoped <- self$index
       self$depends <- depends
       lockBinding("root", self)
       lockBinding("depends", self)
@@ -46,34 +44,6 @@ query_index <- R6::R6Class(
     },
 
     #' @description
-    #' Filter the index. This will filter the active index on the ids
-    #'
-    #' @param ids The ids to filter the index on
-    #' @return Nothing, called for side effect
-    filter = function(ids) {
-      self$index <- self$index[self$index$id %in% ids, ]
-      invisible(TRUE)
-    },
-
-    #' @description
-    #' Get the unfiltered & unscoped index, this is the index as it was
-    #' when this object was created, before any filtering on scoping.
-    #'
-    #' @return A new query_index object with the unfiltered index
-    get_index_unfiltered = function() {
-      query_index$new(self$root, private$index_unfiltered, private$depends)
-    },
-
-    #' @description
-    #' Get the scoped index, this is the index without any filtering but
-    #' with scope rules applied.
-    #'
-    #' @return A new query_index object with the scoped index
-    get_index_scoped = function() {
-      query_index$new(self$root, private$index_scoped, private$depends)
-    },
-
-    #' @description
     #' Get the ids of packets which this packet depends to a specified level
     #'
     #' @param id The id of the packet to get parents of
@@ -88,11 +58,6 @@ query_index <- R6::R6Class(
   ),
 
   private = list(
-    # The unfiltered unscoped index of all packets
-    index_unfiltered = NULL,
-    # The unfiltered index but scoped index of packets
-    index_scoped = NULL,
-
     get_all_packet_depends = function(id, depth) {
       if (depth <= 0) {
         return(character(0))

--- a/man/outpack_query.Rd
+++ b/man/outpack_query.Rd
@@ -28,8 +28,7 @@ will be intersected with \code{scope} arg and is a shorthand way of running
 \code{scope = list(name = "name")}}
 
 \item{subquery}{Optionally, named list of subqueries which can be
-referenced by name from the \code{expr}. Each subquery must be a list
-with at least an \code{expr} and optionally a \code{scope}.}
+referenced by name from the \code{expr}.}
 
 \item{require_unpacked}{Logical, indicating if we should require
 that the packets are unpacked. If \code{FALSE} (the default) we

--- a/man/query_index.Rd
+++ b/man/query_index.Rd
@@ -10,7 +10,7 @@ Class for managing the active index whilst evaluating a query
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
-\item{\code{index}}{The active index}
+\item{\code{index}}{The packet index}
 
 \item{\code{depends}}{Named list of data frames. Names are packet ids, values
 are packets dependend on by this packet id (i.e. its parents).}
@@ -24,9 +24,6 @@ are packets dependend on by this packet id (i.e. its parents).}
 \itemize{
 \item \href{#method-query_index-new}{\code{query_index$new()}}
 \item \href{#method-query_index-scope}{\code{query_index$scope()}}
-\item \href{#method-query_index-filter}{\code{query_index$filter()}}
-\item \href{#method-query_index-get_index_unfiltered}{\code{query_index$get_index_unfiltered()}}
-\item \href{#method-query_index-get_index_scoped}{\code{query_index$get_index_scoped()}}
 \item \href{#method-query_index-get_packet_depends}{\code{query_index$get_packet_depends()}}
 }
 }
@@ -71,54 +68,6 @@ and save the scoped index for use later
 }
 \subsection{Returns}{
 Nothing, called for side effect
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-query_index-filter"></a>}}
-\if{latex}{\out{\hypertarget{method-query_index-filter}{}}}
-\subsection{Method \code{filter()}}{
-Filter the index. This will filter the active index on the ids
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{query_index$filter(ids)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{ids}}{The ids to filter the index on}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Nothing, called for side effect
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-query_index-get_index_unfiltered"></a>}}
-\if{latex}{\out{\hypertarget{method-query_index-get_index_unfiltered}{}}}
-\subsection{Method \code{get_index_unfiltered()}}{
-Get the unfiltered & unscoped index, this is the index as it was
-when this object was created, before any filtering on scoping.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{query_index$get_index_unfiltered()}\if{html}{\out{</div>}}
-}
-
-\subsection{Returns}{
-A new query_index object with the unfiltered index
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-query_index-get_index_scoped"></a>}}
-\if{latex}{\out{\hypertarget{method-query_index-get_index_scoped}{}}}
-\subsection{Method \code{get_index_scoped()}}{
-Get the scoped index, this is the index without any filtering but
-with scope rules applied.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{query_index$get_index_scoped()}\if{html}{\out{</div>}}
-}
-
-\subsection{Returns}{
-A new query_index object with the scoped index
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-query-index.R
+++ b/tests/testthat/test-query-index.R
@@ -1,18 +1,3 @@
-test_that("index can be filtered for querying", {
-  tmp <- temp_file()
-  root <- outpack_init(tmp, use_file_store = TRUE)
-  ids <- vcapply(1:3, function(i) create_random_packet(tmp))
-
-  index <- new_query_index(root, FALSE)
-  expect_setequal(index$index$id, ids)
-  expect_equal(index$index, index$get_index_unfiltered()$index)
-
-  index$filter(ids[[1]])
-  expect_equal(index$index$id, ids[[1]])
-  expect_setequal(index$get_index_unfiltered()$index$id, ids)
-})
-
-
 test_that("index can include only unpacked packets", {
   t <- temp_file()
   path <- list()
@@ -44,21 +29,6 @@ test_that("index can include only unpacked packets", {
 })
 
 
-test_that("index can be scoped", {
-  tmp <- temp_file()
-  root <- outpack_init(tmp, use_file_store = TRUE)
-  ids <- vcapply(1:3, function(i) create_random_packet(tmp))
-
-  index <- new_query_index(root, FALSE)
-  expect_setequal(index$index$id, ids)
-  expect_equal(index$index, index$get_index_scoped()$index)
-
-  index$scope(ids[[1]])
-  expect_equal(index$index$id, ids[[1]])
-  expect_setequal(index$get_index_scoped()$index$id, ids[[1]])
-})
-
-
 test_that("index includes depends info", {
   tmp <- temp_file()
   root <- outpack_init(tmp, use_file_store = TRUE)
@@ -79,17 +49,4 @@ test_that("index includes depends info", {
                   ids[c("a", "b", "c")])
   ## There is no double counting of dependencies
   expect_length(index$get_packet_depends(ids["d"], Inf), 3)
-
-  ## when we filter index
-  index$filter(ids[c("b", "c")])
-
-  ## then results from get_packet_depends are filtered too
-  expect_equal(index$get_packet_depends(ids["a"], 1),     character(0))
-  expect_equal(index$get_packet_depends(ids["a"], Inf),    character(0))
-  expect_setequal(index$get_packet_depends(ids["b"], 1),  character(0))
-  expect_setequal(index$get_packet_depends(ids["b"], Inf), character(0))
-  expect_setequal(index$get_packet_depends(ids["c"], 1),  ids["b"])
-  expect_setequal(index$get_packet_depends(ids["c"], Inf), ids["b"])
-  expect_setequal(index$get_packet_depends(ids["d"], 1),  ids[c("b", "c")])
-  expect_setequal(index$get_packet_depends(ids["d"], Inf), ids[c("b", "c")])
 })

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -860,3 +860,12 @@ test_that("usedby depth works as expected", {
       usedby({latest(name == "c")}, depth = Inf)), root = root), # nolint
     ids[c("a", "b")])
 })
+
+
+test_that("useful errors returned when scope is invalid type", {
+  tmp <- temp_file()
+  root <- outpack_init(tmp, use_file_store = TRUE)
+
+  expect_error(outpack_query(quote(latest()), scope = "the scope", root = root),
+               "Invalid input for `scope`, it must be a language expression.")
+})


### PR DESCRIPTION
This PR will
* Instead of applying the scope to filter the index at the start it instead will append the scope as an `&&` to the expression, or if the expression outer function is a call to `latest` or `single` it will append the scope as an `&&` inside this top level call

This means we don't have to track filtered and unfiltered index and instead every expression is evaluated on the unfiltered index. We can look at optimisations later if it becomes a problem.