### PR TITLE
Optionally raise error from outpack_query if no packets are found

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -24,6 +24,9 @@
 ##'   regardless of if they are locally available, but if `TRUE`, only
 ##'   unpacked packets will be considered.
 ##'
+##' @param error_no_packets Logical, if `TRUE` then `outpack_query` will
+##'   error if no packets are found for this search.
+##'
 ##' @param root The outpack root. Will be searched for from the
 ##'   current directory if not given.
 ##'
@@ -32,7 +35,9 @@
 outpack_query <- function(expr, pars = NULL, scope = NULL,
                           name = NULL, subquery = NULL,
                           require_unpacked = FALSE,
+                          error_no_packets = FALSE,
                           root = NULL) {
+  assert_logical(error_no_packets)
   root <- outpack_root_open(root, locate = TRUE)
   if (!is.null(subquery)) {
     assert_named(subquery, unique = TRUE)
@@ -59,7 +64,12 @@ outpack_query <- function(expr, pars = NULL, scope = NULL,
   validate_parameters(pars)
   index <- new_query_index(root, require_unpacked)
 
-  query_eval(expr_parsed, index, pars, subquery_env)
+  ids <- query_eval(expr_parsed, index, pars, subquery_env)
+
+  if (error_no_packets && (is.na(ids) || length(ids) == 0)) {
+    query_eval_error("Found no packets", expr, expr)
+  }
+  ids
 }
 
 

--- a/man/outpack_query.Rd
+++ b/man/outpack_query.Rd
@@ -11,6 +11,7 @@ outpack_query(
   name = NULL,
   subquery = NULL,
   require_unpacked = FALSE,
+  error_no_packets = FALSE,
   root = NULL
 )
 }
@@ -35,6 +36,9 @@ that the packets are unpacked. If \code{FALSE} (the default) we
 search through all packets known to this outpack root,
 regardless of if they are locally available, but if \code{TRUE}, only
 unpacked packets will be considered.}
+
+\item{error_no_packets}{Logical, if \code{TRUE} then \code{outpack_query} will
+error if no packets are found for this search.}
 
 \item{root}{The outpack root. Will be searched for from the
 current directory if not given.}

--- a/man/query_index.Rd
+++ b/man/query_index.Rd
@@ -15,6 +15,9 @@ Class for managing the active index whilst evaluating a query
 \item{\code{depends}}{Named list of data frames. Names are packet ids, values
 are packets dependend on by this packet id (i.e. its parents).}
 
+\item{\code{uses}}{Named list of data frames. Names are packet ids, values
+are packets which are used by this packet id (i.e. its children).}
+
 \item{\code{root}}{The outpack root object}
 }
 \if{html}{\out{</div>}}
@@ -25,6 +28,7 @@ are packets dependend on by this packet id (i.e. its parents).}
 \item \href{#method-query_index-new}{\code{query_index$new()}}
 \item \href{#method-query_index-scope}{\code{query_index$scope()}}
 \item \href{#method-query_index-get_packet_depends}{\code{query_index$get_packet_depends()}}
+\item \href{#method-query_index-get_packet_uses}{\code{query_index$get_packet_uses()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -33,7 +37,7 @@ are packets dependend on by this packet id (i.e. its parents).}
 \subsection{Method \code{new()}}{
 Create a new query_index object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{query_index$new(root, index, depends)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{query_index$new(root, index, depends, uses)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -45,6 +49,11 @@ Create a new query_index object
 
 \item{\code{depends}}{Named list of data frames. Names are packet ids, values
 are packets dependend on by this packet id (i.e. its parents).}
+
+\item{\code{uses}}{Named list of data frames. Names are packet ids, values
+are packets used by on by this packet id (i.e. its children). This is
+the same data as \code{depends} but relationships flow in the other
+direction.}
 }
 \if{html}{\out{</div>}}
 }
@@ -92,6 +101,30 @@ recurse the whole tree to get all parents}
 }
 \subsection{Returns}{
 The ids of the parents of this packet
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-query_index-get_packet_uses"></a>}}
+\if{latex}{\out{\hypertarget{method-query_index-get_packet_uses}{}}}
+\subsection{Method \code{get_packet_uses()}}{
+Get the ids of packets which are used by this packet
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{query_index$get_packet_uses(id, depth)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{id}}{The id of the packet to get children of}
+
+\item{\code{depth}}{Depth of children to get, \code{depth} 1 gets immediate children
+\code{depth} 2 gets children and children of children, \code{depth} Inf will
+recurse the whole tree to get all children}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The ids of the children of this packet
 }
 }
 }

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -999,3 +999,28 @@ test_that("uses and usedby can be used together", {
       root = root),
     ids["d"])
 })
+
+
+test_that("can error if no packets found", {
+  tmp <- temp_file()
+  root <- outpack_init(tmp, use_file_store = TRUE)
+  expect_equal(
+    outpack_query(quote(name == "other"), root = root),
+    character(0))
+  expect_equal(
+    outpack_query(quote(latest(name == "other")), root = root),
+    NA_character_)
+
+  expect_error(
+    outpack_query(quote(name == "other"),
+                  error_no_packets = TRUE, root = root),
+    paste0("Found no packets\n",
+           "  - while evaluating name == \"other\""),
+    fixed = TRUE)
+  expect_error(
+    outpack_query(quote(latest(name == "other")),
+                  error_no_packets = TRUE, root = root),
+    paste0("Found no packets\n",
+           "  - while evaluating latest(name == \"other\")"),
+    fixed = TRUE)
+})


### PR DESCRIPTION
When running the query from orderly we probably want to error if the packet isn't found as the dependency can't be satisfied. We could either do that here or in orderly but felt like something which might be generally useful so I added here.
