### PR TITLE
Allow repeated calls to outpack_packet_file_mark

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/packet.R
+++ b/R/packet.R
@@ -345,11 +345,10 @@ outpack_packet_file_mark <- function(files, status, packet = NULL) {
                    paste(squote(intersect(files, p$files$ignored)),
                          collapse = ", ")))
     }
-    if (any(files %in% names(p$files$immutable))) {
-      validate_hashes(value, p$files$immutable)
-      value <- value[!(names(value) %in% names(p$files))]
-    }
 
+    prev <- names(p$files$immutable)
+    validate_hashes(value, p$files$immutable[intersect(files, prev)])
+    value <- value[setdiff(names(value), prev)]
     p$files$immutable <- c(p$files$immutable, value)
   } else if (status == "ignored") {
     if (any(files %in% names(p$files$immutable))) {


### PR DESCRIPTION
Found this while working on an orderly feature