### PR TITLE
Refactor queries

### DIFF
--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -650,7 +650,7 @@ test_that("subqueries cannot be used within at_location", {
 
   expect_error(
     outpack_query(quote(at_location({sub})), # nolint
-                  subquery = list(sub = quote("x")),
+                  subquery = list(sub = quote("latest")),
                   root = root),
     paste0("All arguments to at_location() must be string literals\n",
            "  - in at_location({sub})"),


### PR DESCRIPTION
This is an attempt to make the flow of data through subqueries a bit easier to understand (at least for me). I think it's a bit tidier now, but see what you think.

The primary innovation is that the subquery environment always contains elements which are a named list with elements representing their name, the original query, the parsed query, the result and booleans which indicate if they were anonymous and if they have been evaluated. This the makes a bit less magic some of the use of these elements.

I've also removed some repetition in `query_parse_expr`