### PR TITLE
Normalize path to deal with windows slashes/shortening

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/root.R
+++ b/R/root.R
@@ -113,6 +113,7 @@ outpack_root <- R6::R6Class(
     initialize = function(path) {
       assert_file_exists(path)
       assert_file_exists(file.path(path, ".outpack"))
+      path <- as.character(fs::path_real(path))
       self$path <- path
       self$config <- config_read(path)
       if (self$config$core$use_file_store) {


### PR DESCRIPTION
Merge and then orderly3 can depend on outpack >= 0.3.1 and tests should pass with consistent paths...