### PR TITLE
Allow interpolating subqueries back into main query

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -280,15 +280,15 @@ is_id_lookup <- function(expr) {
 
 query_error <- function(msg, expr, context, prefix) {
   if (identical(expr, context)) {
-    stop(sprintf("%s\n  - %s %s", msg, prefix, deparse_query(expr)),
+    stop(sprintf("%s\n  - %s %s", msg, prefix, deparse_query(expr, NULL)),
          call. = FALSE)
   } else {
     width <- max(nchar(prefix), nchar("within"))
     stop(sprintf(
       "%s\n  - %s %s\n  - %s %s",
       msg,
-      format(prefix, width = width), deparse_query(expr),
-      format("within", width = width), deparse_query(context)),
+      format(prefix, width = width), deparse_query(expr, NULL),
+      format("within", width = width), deparse_query(context, NULL)),
       call. = FALSE)
   }
 }
@@ -308,7 +308,7 @@ query_parse_check_call <- function(expr, context) {
   if (!is.call(expr)) {
     query_parse_error(sprintf(
       "Invalid query '%s'; expected some sort of expression",
-      deparse_query(expr)),
+      deparse_query(expr, NULL)),
       expr, context)
   }
 
@@ -330,7 +330,7 @@ query_parse_check_call <- function(expr, context) {
   if (is.null(len)) {
     query_parse_error(sprintf(
       "Invalid query '%s'; unknown query component '%s'",
-      deparse_query(expr), fn),
+      deparse_query(expr, NULL), fn),
       expr, context)
   }
 
@@ -372,7 +372,7 @@ query_parse_value <- function(expr, context, subquery_env) {
     list(type = "lookup",
          name = deparse(expr))
   } else if (is_call(expr, ":")) {
-    name <- deparse_query(expr[[2]])
+    name <- deparse_query(expr[[2]], NULL)
     valid <- c("parameter", "this")
     if (!(name %in% valid)) {
         query_parse_error(sprintf(
@@ -380,13 +380,13 @@ query_parse_value <- function(expr, context, subquery_env) {
     }
     list(type = "lookup",
          name = name,
-         query = deparse_query(expr[[3]]),
+         query = deparse_query(expr[[3]], NULL),
          expr = expr,
          context = context)
   } else {
     query_parse_error(
       sprintf("Unhandled query expression value '%s'",
-              deparse_query(expr)),
+              deparse_query(expr, NULL)),
       expr, context)
   }
 }
@@ -411,7 +411,7 @@ make_subquery_env <- function(subquery) {
 add_subquery <- function(name, expr, context, subquery_env) {
   anonymous <- is.null(name)
   if (anonymous) {
-    name <- openssl::md5(deparse_query(expr))
+    name <- openssl::md5(deparse_query(expr, NULL))
   }
   subquery_env[[name]] <- list(
     name = name,

--- a/R/query_deparse.R
+++ b/R/query_deparse.R
@@ -21,16 +21,11 @@ outpack_query_format <- function(query, subquery = NULL) {
   }
 
   if (!is.null(subquery)) {
-    ## ## This branch is going to be hit internally:
-    ## if (is.environment(subquery)) {
-    ##   subquery <- set_names(lapply(names(subquery), function(x) x$expr),
-    ##                         names(subquery))
-    ## }
     assert_named(subquery)
     ok <- vlapply(subquery, is_deparseable_query)
     if (!all(ok)) {
-      stop("Invalid query, it must be deparseable: error for %s",
-           paste(squote(names(subquery)[!ok]), collapse = ", "))
+      stop(sprintf("Invalid subquery, it must be deparseable: error for %s",
+                   paste(squote(names(subquery)[!ok]), collapse = ", ")))
     }
   }
 

--- a/R/query_deparse.R
+++ b/R/query_deparse.R
@@ -2,21 +2,48 @@
 #'
 #' @param query The outpack query to print
 #'
+#' @param subquery Optionally a named list of subqueries - if given,
+#'   each must be a valid deparseable subquery (i.e., a literal or
+#'   language object).  Note that you must not provide an
+#'   already-deparsed query here or it will get quoted!
+#'
 #' @return Query expression as a string
 #' @export
 #'
 #' @examples
-#' outpack_query_format(quote(name == "example"))
-outpack_query_format <- function(query) {
-  ok <- is.language(query) || (is.atomic(query) && length(query) == 1)
-  if (!ok) {
+#' outpack::outpack_query_format(quote(name == "example"))
+#' outpack::outpack_query_format(
+#'   quote(usedby({A})),
+#'   subquery = list(A = quote(latest(name == "a"))))
+outpack_query_format <- function(query, subquery = NULL) {
+  if (!is_deparseable_query(query)) {
     stop("Cannot format query, it must be a language object or be length 1.")
   }
-  deparse_query(query)
+
+  if (!is.null(subquery)) {
+    ## ## This branch is going to be hit internally:
+    ## if (is.environment(subquery)) {
+    ##   subquery <- set_names(lapply(names(subquery), function(x) x$expr),
+    ##                         names(subquery))
+    ## }
+    assert_named(subquery)
+    ok <- vlapply(subquery, is_deparseable_query)
+    if (!all(ok)) {
+      stop("Invalid query, it must be deparseable: error for %s",
+           paste(squote(names(subquery)[!ok]), collapse = ", "))
+    }
+  }
+
+  deparse_query(query, subquery)
 }
 
 
-deparse_query <- function(x) {
+is_deparseable_query <- function(x) {
+  is.language(x) || (is.atomic(x) && length(x) == 1)
+}
+
+
+deparse_query <- function(x, subquery) {
   if (length(x) == 1) {
     return(deparse_single(x))
   }
@@ -32,14 +59,14 @@ deparse_query <- function(x) {
   bracket_operators <- list("(" = ")", "{" = "}", "[" = "]")
 
   if (fn %in% infix_operators && length(args) == 2) {
-    query_str <- deparse_infix(fn, args)
+    query_str <- deparse_infix(fn, args, subquery)
   } else if (fn %in% prefix_operators) {
-    query_str <- deparse_prefix(fn, args)
+    query_str <- deparse_prefix(fn, args, subquery)
   } else if (fn %in% names(bracket_operators)) {
     closing <- bracket_operators[[fn]]
-    query_str <- deparse_brackets(fn, args, closing)
+    query_str <- deparse_brackets(fn, args, subquery, closing)
   } else {
-    query_str <- deparse_regular_function(fn, args)
+    query_str <- deparse_regular_function(fn, args, subquery)
   }
   query_str
 }
@@ -54,29 +81,39 @@ deparse_single <- function(x) {
   str
 }
 
-deparse_prefix <- function(fn, args) {
-  deparse_regular_function(fn, args,
+deparse_prefix <- function(fn, args, subquery) {
+  deparse_regular_function(fn, args, subquery,
                            opening_bracket = "", closing_bracket = "")
 }
 
-deparse_infix <- function(fn, args) {
+deparse_infix <- function(fn, args, subquery) {
   sep <- if (fn == ":") "" else " "
-  paste(deparse_query(args[[1]]), fn,
-        deparse_query(args[[2]]), sep = sep)
+  paste(deparse_query(args[[1]], subquery), fn,
+        deparse_query(args[[2]], subquery), sep = sep)
 }
 
-deparse_brackets <- function(fn, args, closing) {
+deparse_brackets <- function(fn, args, subquery, closing) {
   if (fn == "[") {
     func <- args[[1]]
     args <- args[-1]
   } else {
     func <- ""
   }
-  deparse_regular_function(func, args, fn, closing)
+
+  if (fn == "{" && !is.null(subquery)) {
+    if (length(args[[1]]) == 1 && is.name(args[[1]])) {
+      sub <- subquery[[as.character(args[[1]])]]
+      if (!is.null(sub)) {
+        args[[1]] <- sub
+      }
+    }
+  }
+
+  deparse_regular_function(func, args, subquery, fn, closing)
 }
 
-deparse_regular_function <- function(fn, args, opening_bracket = "(",
+deparse_regular_function <- function(fn, args, subquery, opening_bracket = "(",
                                      closing_bracket = ")") {
-  arg_str <- paste(vcapply(args, deparse_query), collapse = ", ")
+  arg_str <- paste(vcapply(args, deparse_query, subquery), collapse = ", ")
   paste0(fn, opening_bracket, arg_str, closing_bracket)
 }

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -54,7 +54,7 @@ of \code{NULL} uses the root value, otherwise use \code{info}, \code{debug} or
 \item{root}{The outpack root. Will be searched for from the
 current directory if not given.}
 
-\item{packet}{Optionally, an explicitly-passed packet; see Details}
+\item{packet}{A packet object}
 
 \item{script}{Path to the script within the packet directory (a
 relative path).  This function can be safely called multiple

--- a/man/outpack_query_format.Rd
+++ b/man/outpack_query_format.Rd
@@ -4,10 +4,15 @@
 \alias{outpack_query_format}
 \title{Format outpack query for displaying to users}
 \usage{
-outpack_query_format(query)
+outpack_query_format(query, subquery = NULL)
 }
 \arguments{
 \item{query}{The outpack query to print}
+
+\item{subquery}{Optionally a named list of subqueries - if given,
+each must be a valid deparseable subquery (i.e., a literal or
+language object).  Note that you must not provide an
+already-deparsed query here or it will get quoted!}
 }
 \value{
 Query expression as a string
@@ -16,5 +21,8 @@ Query expression as a string
 Format outpack query for displaying to users
 }
 \examples{
-outpack_query_format(quote(name == "example"))
+outpack::outpack_query_format(quote(name == "example"))
+outpack::outpack_query_format(
+  quote(usedby({A})),
+  subquery = list(A = quote(latest(name == "a"))))
 }

--- a/tests/testthat/test-query-deparse.R
+++ b/tests/testthat/test-query-deparse.R
@@ -45,25 +45,25 @@ test_that("queries can be deparsed", {
 test_that("subqueries can be interpolated into deparsed queries", {
   subquery <- list(A = "123",
                    B = quote(latest(name == "b")),
-                   C = quote(latest(usedby({A}))))
+                   C = quote(latest(usedby({A})))) # nolint
   expect_equal(
-    outpack_query_format(quote(latest(usedby({A}))), subquery),
+    outpack_query_format(quote(latest(usedby({A}))), subquery), # nolint
     'latest(usedby({"123"}))')
   expect_equal(
-    outpack_query_format(quote(latest(usedby({B}))), subquery),
+    outpack_query_format(quote(latest(usedby({B}))), subquery), # nolint
     'latest(usedby({latest(name == "b")}))')
   expect_equal(
-    outpack_query_format(quote(latest(usedby({Z}))), subquery),
-    'latest(usedby({Z}))')
+    outpack_query_format(quote(latest(usedby({Z}))), subquery), # nolint
+    "latest(usedby({Z}))")
   ## Does recurse, for better or worse:
   expect_equal(
-    outpack_query_format(quote(latest(usedby({C}))), subquery),
+    outpack_query_format(quote(latest(usedby({C}))), subquery), # nolint
     'latest(usedby({latest(usedby({"123"}))}))')
 })
 
 
 test_that("subqueries must be sensible", {
   expect_error(
-    outpack_query_format(quote(latest(usedby({A}))), list(A = list()))
+    outpack_query_format(quote(latest(usedby({A}))), list(A = list())), # nolint
     "Invalid subquery, it must be deparseable: error for 'A'")
 })

--- a/tests/testthat/test-query-deparse.R
+++ b/tests/testthat/test-query-deparse.R
@@ -60,3 +60,10 @@ test_that("subqueries can be interpolated into deparsed queries", {
     outpack_query_format(quote(latest(usedby({C}))), subquery),
     'latest(usedby({latest(usedby({"123"}))}))')
 })
+
+
+test_that("subqueries must be sensible", {
+  expect_error(
+    outpack_query_format(quote(latest(usedby({A}))), list(A = list()))
+    "Invalid subquery, it must be deparseable: error for 'A'")
+})

--- a/tests/testthat/test-query-deparse.R
+++ b/tests/testthat/test-query-deparse.R
@@ -40,3 +40,23 @@ test_that("queries can be deparsed", {
     outpack_query_format(c("one", "two")),
     "Cannot format query, it must be a language object or be length 1.")
 })
+
+
+test_that("subqueries can be interpolated into deparsed queries", {
+  subquery <- list(A = "123",
+                   B = quote(latest(name == "b")),
+                   C = quote(latest(usedby({A}))))
+  expect_equal(
+    outpack_query_format(quote(latest(usedby({A}))), subquery),
+    'latest(usedby({"123"}))')
+  expect_equal(
+    outpack_query_format(quote(latest(usedby({B}))), subquery),
+    'latest(usedby({latest(name == "b")}))')
+  expect_equal(
+    outpack_query_format(quote(latest(usedby({Z}))), subquery),
+    'latest(usedby({Z}))')
+  ## Does recurse, for better or worse:
+  expect_equal(
+    outpack_query_format(quote(latest(usedby({C}))), subquery),
+    'latest(usedby({latest(usedby({"123"}))}))')
+})


### PR DESCRIPTION
This is work broken out of the dependencies work - allow deparse of `latest({A})` to interpolate the deparsed value of subquery `A` while deparsing, optionally. This will be useful for constructing the version of the query we save into metadata.

There's a motivating example in the tests:

```r
subquery <- list(A = "123",
                 B = quote(latest(name == "b")),
                 C = quote(latest(usedby({A}))))
# Simple case:
outpack_query_format(quote(latest(usedby({A}))), subquery)
# > latest(usedby({"123"}))

# Deparse nested expressions
outpack_query_format(quote(latest(usedby({B}))), subquery)
# > latest(usedby({latest(name == "b")}))

# Skip over missing bits, so we never fail
outpack_query_format(quote(latest(usedby({Z}))), subquery)
# > latest(usedby({Z}))

# Handle recursive subexpressions!
outpack_query_format(quote(latest(usedby({C}))), subquery)
# > latest(usedby({latest(usedby({"123"}))}))
```