### PR TITLE
Workaround for testthat reacting to the 'trace' element

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -64,13 +64,13 @@ source_and_capture <- function(path, envir, echo) {
           error = function(e) {
             try(stop(e))
             env$error <- e
-            env$trace <- utils::limitedLabels(sys.calls())
+            env$traceback <- utils::limitedLabels(sys.calls())
           }))),
     error = identity)
 
   list(success = is.null(env$error),
        error = env$error,
-       trace = env$trace,
+       traceback = env$traceback,
        warnings = env$warnings$get(),
        output = readLines(tmp))
 }

--- a/R/packet.R
+++ b/R/packet.R
@@ -167,7 +167,7 @@ outpack_packet_end <- function(packet, insert = TRUE) {
 ##'   about the error:
 ##'
 ##' * `error`: the original error object, as thrown and caught by `outpack`
-##' * `trace`: the backtrace for the above error, currently just as a
+##' * `traceback`: the backtrace for the above error, currently just as a
 ##'   character vector, though this may change in future versions
 ##' * `output`: a character vector of interleaved stdout and stderr as
 ##'   the script ran
@@ -203,8 +203,8 @@ outpack_packet_run <- function(packet, script, envir = .GlobalEnv) {
   status <- if (result$success) "success" else "failure"
   outpack_log_info(packet, "result", status, caller)
   outpack_log_info(packet, "output", I(result$output), caller)
-  if (length(result$trace) > 0) {
-    outpack_log_info(packet, "trace", I(result$trace), caller)
+  if (length(result$traceback) > 0) {
+    outpack_log_info(packet, "traceback", I(result$traceback), caller)
   }
   if (length(result$warnings) > 0) {
     warnings_str <- vcapply(result$warnings, conditionMessage)

--- a/tests/testthat/test-packet.R
+++ b/tests/testthat/test-packet.R
@@ -607,14 +607,15 @@ f(5)',
     "Script failed with error: x became negative",
     class = "outpack_packet_run_error")
   outpack_packet_end(p, FALSE)
-  expect_setequal(
+  setequal(
     names(err),
-    c("success", "message", "error", "trace", "output", "warnings"))
+    c("success", "message", "error", "traceback", "output", "warnings",
+      "trace")) # last trace added by testthat!
 
   expect_false(err$success)
   expect_equal(err$message, "Script failed with error: x became negative")
-  expect_type(err$trace, "character")
-  expect_true(length(err$trace) > 5)
+  expect_type(err$traceback, "character")
+  expect_true(length(err$traceback) > 5)
   expect_match(err$output,
                "Error in f(x - 1) : x became negative",
                fixed = TRUE, all = FALSE)
@@ -622,9 +623,9 @@ f(5)',
   expect_true(file.exists(file.path(path_src, "log.json")))
   d <- log_read(file.path(path_src, "log.json"))
 
-  i_trace <- which(d$topic == "trace")
-  expect_length(i_trace, 1)
-  expect_equal(d$detail[[i_trace]], err$trace)
+  i_traceback <- which(d$topic == "traceback")
+  expect_length(i_traceback, 1)
+  expect_equal(d$detail[[i_traceback]], err$traceback)
 })
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -15,7 +15,7 @@ test_that("Descend failure", {
 })
 
 
-test_that("can source script that fails with error, reporting trace", {
+test_that("can source script that fails with error, reporting traceback", {
   path <- withr::local_tempfile(fileext = ".R")
   code <- 'f <- function(x) {
   message("calling with x = ", x)
@@ -31,11 +31,11 @@ f(5)'
   res <- source_and_capture(path, envir, FALSE)
 
   expect_setequal(names(res),
-                  c("success", "error", "trace", "warnings", "output"))
+                  c("success", "error", "traceback", "warnings", "output"))
   expect_false(res$success)
   expect_s3_class(res$error, "error")
   expect_equal(res$warnings, list())
-  expect_type(res$trace, "character")
+  expect_type(res$traceback, "character")
 
   skip_on_cran() # depends on details
   output <- strsplit(code, "\n")[[1]]


### PR DESCRIPTION
This stops orderly choking; see for example:

```
> test_that("Can run simple case with dependency", {
+   path <- test_prepare_orderly_example(c("parameters", "depends"))
+   env1 <- new.env()
+   id1 <- orderly_run("parameters", root = path, envir = env1,
+                      parameters = list(a = 10, b = 20, c = 30))
+   env2 <- new.env()
+   id2 <- orderly_run("depends", root = path, envir = env2)
+ 
+   path1 <- file.path(path, "archive", "parameters", id1)
+   path2 <- file.path(path, "archive", "depends", id2)
+ 
+   expect_true(file.exists(file.path(path2, "input.rds")))
+   expect_equal(
+     unname(tools::md5sum(file.path(path2, "input.rds"))),
+     unname(tools::md5sum(file.path(path1, "data.rds"))))
+ })
── Error (Line 7): Can run simple case with dependency ─────────────────────────
<outpack_packet_run_error/error/condition>
Error: Script failed with error: object 'y' not found
Backtrace:
 1. orderly3::orderly_run("depends", root = path, envir = env2)
 3. outpack::outpack_packet_run(p, "orderly.R", envir)
      at orderly3/R/run.R:92:4
```

(in the https://github.com/mrc-ide/orderly3/pull/20 example)