### PR TITLE
Check name argument to outpack_query

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -23,6 +23,7 @@ outpack_query <- function(expr, name = NULL, scope = NULL, subquery = NULL) {
   subquery_env <- make_subquery_env(subquery)
   expr_parsed <- query_parse(expr, expr, subquery_env)
   if (!is.null(name)) {
+    assert_scalar_character(name)
     name_call <- call("==", quote(name), name)
     if (is.null(scope)) {
       scope <- name_call

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -241,3 +241,10 @@ test_that("include parameters from subqueries too", {
                        subquery = list(B = quote(parameter:x < this:y)))
   expect_equal(obj$info$parameters, "y")
 })
+
+
+test_that("validate inputs to outpack_query", {
+  expect_error(
+    outpack_query("latest", list(a = 1)),
+    "'name' must be character")
+})


### PR DESCRIPTION
Tiny PR, but this produces a much better error in the case of badly passed args.

The lack of this assertion complicated getting to the source of the bug that Alex found yesterday, PR for that one incoming soon