### PR TITLE
Allow path = NULL to use working directory to find root

### DIFF
--- a/R/root.R
+++ b/R/root.R
@@ -178,7 +178,8 @@ outpack_root <- R6::R6Class(
 ##' @title Open outpack root
 ##'
 ##' @param path The path to look for the root; must be an existing
-##'   directory. Use `.` or `getwd()` for the current directory.
+##'   directory. Use `NULL` (or `.` or `getwd()`) for the current
+##'   directory.
 ##'
 ##' @param locate Logical, indicating if we should look in parent
 ##'   directories until the root is found (similar behaviour to how
@@ -192,6 +193,9 @@ outpack_root <- R6::R6Class(
 outpack_root_open <- function(path, locate = TRUE) {
   if (inherits(path, "outpack_root")) {
     return(path)
+  }
+  if (is.null(path)) {
+    path <- getwd()
   }
   assert_scalar_character(path)
   assert_directory(path)

--- a/man/outpack_root_open.Rd
+++ b/man/outpack_root_open.Rd
@@ -8,7 +8,8 @@ outpack_root_open(path, locate = TRUE)
 }
 \arguments{
 \item{path}{The path to look for the root; must be an existing
-directory. Use \code{.} or \code{getwd()} for the current directory.}
+directory. Use \code{NULL} (or \code{.} or \code{getwd()}) for the current
+directory.}
 
 \item{locate}{Logical, indicating if we should look in parent
 directories until the root is found (similar behaviour to how

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -125,3 +125,13 @@ test_that("Can read full metadata via root", {
   expect_equal(d1$script, list())
   expect_equal(d1$schema_version, outpack_schema_version())
 })
+
+
+## As used in orderly:
+test_that("can find appropriate root if in working directory with path NULL", {
+  root <- create_temporary_root()
+  res <- withr::with_dir(
+    root$path,
+    outpack_root_open(NULL, TRUE))
+  expect_equal(res$path, root$path)
+})


### PR DESCRIPTION
Currently this fails with a poor error