### PR TITLE
Root utilities for finding missing packets and files

### DIFF
--- a/R/root.R
+++ b/R/root.R
@@ -443,3 +443,27 @@ validate_packet_has_file <- function(root, id, path) {
                  id, paste(squote(err), collapse = ", ")))
   }
 }
+
+
+root_unknown_packets <- function(ids, unpacked, root) {
+  if (unpacked) {
+    setdiff(ids, root$index()$unpacked$packet)
+  } else {
+    setdiff(ids, names(root$index()$metadata))
+  }
+}
+
+
+root_unknown_files <- function(hashes, root) {
+  if (root$config$core$use_file_store) {
+    hashes[!root$files$exists(hashes)]
+  } else {
+    idx <- root$index()
+    if (length(idx$unpacked$packet) == 0) {
+      return(hashes)
+    }
+    ## This could be quite a slow operation, especially if we always
+    ## validate each file (as we currently do)
+    hashes[vlapply(hashes, function(h) is.null(find_file_by_hash(root, h)))]
+  }
+}

--- a/R/root.R
+++ b/R/root.R
@@ -445,7 +445,7 @@ validate_packet_has_file <- function(root, id, path) {
 }
 
 
-root_unknown_packets <- function(ids, unpacked, root) {
+root_list_unknown_packets <- function(ids, unpacked, root) {
   if (unpacked) {
     setdiff(ids, root$index()$unpacked$packet)
   } else {
@@ -454,7 +454,7 @@ root_unknown_packets <- function(ids, unpacked, root) {
 }
 
 
-root_unknown_files <- function(hashes, root) {
+root_list_unknown_files <- function(hashes, root) {
   if (root$config$core$use_file_store) {
     hashes[!root$files$exists(hashes)]
   } else {

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -147,20 +147,25 @@ test_that("Can work out what packets are missing", {
   outpack_location_pull_metadata(root = root$b)
 
   ## Nothing missing in this case:
-  expect_equal(root_unknown_packets(ids, TRUE, root$a), character())
-  expect_equal(root_unknown_packets(ids[[1]], TRUE, root$a), character())
-  expect_equal(root_unknown_packets(character(), TRUE, root$a), character())
+  expect_equal(root_list_unknown_packets(ids, TRUE, root$a),
+               character())
+  expect_equal(root_list_unknown_packets(ids[[1]], TRUE, root$a),
+               character())
+  expect_equal(root_list_unknown_packets(character(), TRUE, root$a),
+               character())
 
   ids_fake <- replicate(4, outpack_id())
-  expect_equal(root_unknown_packets(ids_fake, TRUE, root$a), ids_fake)
-  expect_equal(root_unknown_packets(rev(ids_fake), TRUE, root$a), rev(ids_fake))
+  expect_equal(root_list_unknown_packets(ids_fake, TRUE, root$a),
+               ids_fake)
+  expect_equal(root_list_unknown_packets(rev(ids_fake), TRUE, root$a),
+               rev(ids_fake))
 
   ids_all <- sample(c(unname(ids), ids_fake))
-  expect_equal(root_unknown_packets(ids_all, TRUE, root$a),
+  expect_equal(root_list_unknown_packets(ids_all, TRUE, root$a),
                setdiff(ids_all, ids))
-  expect_equal(root_unknown_packets(ids_all, TRUE, root$b),
+  expect_equal(root_list_unknown_packets(ids_all, TRUE, root$b),
                ids_all)
-  expect_equal(root_unknown_packets(ids_all, FALSE, root$b),
+  expect_equal(root_list_unknown_packets(ids_all, FALSE, root$b),
                setdiff(ids_all, ids))
 })
 
@@ -172,15 +177,15 @@ test_that("Can work out what files are missing", {
   files <- root$files$list()
   files_msg <- hash_data(files, "sha256")
 
-  expect_equal(root_unknown_files(files, root), character())
-  expect_equal(root_unknown_files(files[[1]], root), character())
-  expect_equal(root_unknown_files(character(), root), character())
+  expect_equal(root_list_unknown_files(files, root), character())
+  expect_equal(root_list_unknown_files(files[[1]], root), character())
+  expect_equal(root_list_unknown_files(character(), root), character())
 
-  expect_equal(root_unknown_files(files_msg, root), files_msg)
-  expect_equal(root_unknown_files(rev(files_msg), root), rev(files_msg))
+  expect_equal(root_list_unknown_files(files_msg, root), files_msg)
+  expect_equal(root_list_unknown_files(rev(files_msg), root), rev(files_msg))
 
   files_all <- sample(c(files, files_msg))
-  expect_equal(root_unknown_files(files_all, root),
+  expect_equal(root_list_unknown_files(files_all, root),
                setdiff(files_all, files))
 })
 
@@ -194,15 +199,15 @@ test_that("Can work out what files are missing without file store", {
            FALSE, FALSE))
   files_msg <- hash_data(files, "sha256")
 
-  expect_equal(root_unknown_files(files, root), character())
-  expect_equal(root_unknown_files(files[[1]], root), character())
-  expect_equal(root_unknown_files(character(), root), character())
+  expect_equal(root_list_unknown_files(files, root), character())
+  expect_equal(root_list_unknown_files(files[[1]], root), character())
+  expect_equal(root_list_unknown_files(character(), root), character())
 
-  expect_equal(root_unknown_files(files_msg, root), files_msg)
-  expect_equal(root_unknown_files(rev(files_msg), root), rev(files_msg))
+  expect_equal(root_list_unknown_files(files_msg, root), files_msg)
+  expect_equal(root_list_unknown_files(rev(files_msg), root), rev(files_msg))
 
   files_all <- sample(c(files, files_msg))
-  expect_equal(root_unknown_files(files_all, root),
+  expect_equal(root_list_unknown_files(files_all, root),
                setdiff(files_all, files))
 })
 
@@ -210,5 +215,5 @@ test_that("Can work out what files are missing without file store", {
 test_that("All files missing in empty archive", {
   root <- create_temporary_root(use_file_store = FALSE)
   files_msg <- hash_data(1:10, "sha256")
-  expect_equal(root_unknown_files(files_msg, root), files_msg)
+  expect_equal(root_list_unknown_files(files_msg, root), files_msg)
 })

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -205,3 +205,10 @@ test_that("Can work out what files are missing without file store", {
   expect_equal(root_unknown_files(files_all, root),
                setdiff(files_all, files))
 })
+
+
+test_that("All files missing in empty archive", {
+  root <- create_temporary_root(use_file_store = FALSE)
+  files_msg <- hash_data(1:10, "sha256")
+  expect_equal(root_unknown_files(files_msg, root), files_msg)
+})

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -135,3 +135,51 @@ test_that("can find appropriate root if in working directory with path NULL", {
     outpack_root_open(NULL, TRUE))
   expect_equal(res$path, root$path)
 })
+
+
+test_that("Can work out what packets are missing", {
+  root <- list()
+  for (name in c("a", "b")) {
+    root[[name]] <- create_temporary_root()
+  }
+  ids <- create_random_packet_chain(root$a, 3)
+  outpack_location_add("a", "path", list(path = root$a$path), root = root$b)
+  outpack_location_pull_metadata(root = root$b)
+
+  ## Nothing missing in this case:
+  expect_equal(root_unknown_packets(ids, TRUE, root$a), character())
+  expect_equal(root_unknown_packets(ids[[1]], TRUE, root$a), character())
+  expect_equal(root_unknown_packets(character(), TRUE, root$a), character())
+
+  ids_fake <- replicate(4, outpack_id())
+  expect_equal(root_unknown_packets(ids_fake, TRUE, root$a), ids_fake)
+  expect_equal(root_unknown_packets(rev(ids_fake), TRUE, root$a), rev(ids_fake))
+
+  ids_all <- sample(c(unname(ids), ids_fake))
+  expect_equal(root_unknown_packets(ids_all, TRUE, root$a),
+               setdiff(ids_all, ids))
+  expect_equal(root_unknown_packets(ids_all, TRUE, root$b),
+               ids_all)
+  expect_equal(root_unknown_packets(ids_all, FALSE, root$b),
+               setdiff(ids_all, ids))
+})
+
+
+test_that("Can work out what files are missing", {
+  root <- create_temporary_root(use_file_store = TRUE)
+  ids <- create_random_packet_chain(root, 3)
+
+  files <- root$files$list()
+  files_msg <- hash_data(files, "sha256")
+
+  expect_equal(root_unknown_files(files, root), character())
+  expect_equal(root_unknown_files(files[[1]], root), character())
+  expect_equal(root_unknown_files(character(), root), character())
+
+  expect_equal(root_unknown_files(files_msg, root), files_msg)
+  expect_equal(root_unknown_files(rev(files_msg), root), rev(files_msg))
+
+  files_all <- sample(c(unname(files), files_msg))
+  expect_equal(root_unknown_files(files_all, root),
+               setdiff(files_all, files))
+})

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -179,7 +179,29 @@ test_that("Can work out what files are missing", {
   expect_equal(root_unknown_files(files_msg, root), files_msg)
   expect_equal(root_unknown_files(rev(files_msg), root), rev(files_msg))
 
-  files_all <- sample(c(unname(files), files_msg))
+  files_all <- sample(c(files, files_msg))
+  expect_equal(root_unknown_files(files_all, root),
+               setdiff(files_all, files))
+})
+
+
+test_that("Can work out what files are missing without file store", {
+  root <- create_temporary_root(use_file_store = FALSE)
+  ids <- create_random_packet_chain(root, 3)
+
+  files <- unique(
+    unlist(lapply(root$index()$metadata, function(x) x$files$hash),
+           FALSE, FALSE))
+  files_msg <- hash_data(files, "sha256")
+
+  expect_equal(root_unknown_files(files, root), character())
+  expect_equal(root_unknown_files(files[[1]], root), character())
+  expect_equal(root_unknown_files(character(), root), character())
+
+  expect_equal(root_unknown_files(files_msg, root), files_msg)
+  expect_equal(root_unknown_files(rev(files_msg), root), rev(files_msg))
+
+  files_all <- sample(c(files, files_msg))
   expect_equal(root_unknown_files(files_all, root),
                setdiff(files_all, files))
 })


### PR DESCRIPTION
This simplifies import later because it's easy to ask what we don't already have