### PR TITLE
Fix coverage holes

### DIFF
--- a/R/query_index.R
+++ b/R/query_index.R
@@ -41,18 +41,6 @@ query_index <- R6::R6Class(
     },
 
     #' @description
-    #' Scope the index. This will filter the active index on the scope
-    #' and save the scoped index for use later
-    #'
-    #' @param ids The ids to scope the index on
-    #' @return Nothing, called for side effect
-    scope = function(ids) {
-      self$filter(ids)
-      private$index_scoped <- self$index
-      invisible(TRUE)
-    },
-
-    #' @description
     #' Get the ids of packets which this packet depends to a specified level
     #'
     #' @param id The id of the packet to get parents of

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -111,10 +111,6 @@ query_eval_dependency <- function(query, index, parameters, subquery) {
   ## were usedby or used in this one, so find parents/children without scope
   ## and apply scope later when finding the results of the main query.
   id <- query_eval(query$args[[1]], index, parameters, subquery)
-  len <- length(id)
-  if (len == 0) {
-    return(character(0))
-  }
   switch(query$name,
          usedby = index$get_packet_depends(id, query$args[[2]]$value),
          uses = index$get_packet_uses(id, query$args[[2]]$value))

--- a/man/outpack_packet.Rd
+++ b/man/outpack_packet.Rd
@@ -130,7 +130,7 @@ a \code{message} field, additional data fields containing information
 about the error:
 \itemize{
 \item \code{error}: the original error object, as thrown and caught by \code{outpack}
-\item \code{trace}: the backtrace for the above error, currently just as a
+\item \code{traceback}: the backtrace for the above error, currently just as a
 character vector, though this may change in future versions
 \item \code{output}: a character vector of interleaved stdout and stderr as
 the script ran

--- a/man/query_index.Rd
+++ b/man/query_index.Rd
@@ -26,7 +26,6 @@ are packets which are used by this packet id (i.e. its children).}
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-query_index-new}{\code{query_index$new()}}
-\item \href{#method-query_index-scope}{\code{query_index$scope()}}
 \item \href{#method-query_index-get_packet_depends}{\code{query_index$get_packet_depends()}}
 \item \href{#method-query_index-get_packet_uses}{\code{query_index$get_packet_uses()}}
 }
@@ -56,27 +55,6 @@ the same data as \code{depends} but relationships flow in the other
 direction.}
 }
 \if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-query_index-scope"></a>}}
-\if{latex}{\out{\hypertarget{method-query_index-scope}{}}}
-\subsection{Method \code{scope()}}{
-Scope the index. This will filter the active index on the scope
-and save the scoped index for use later
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{query_index$scope(ids)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{ids}}{The ids to scope the index on}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Nothing, called for side effect
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -139,7 +139,7 @@ test_that("control logging threshold", {
   expect_silent(
     outpack_log_debug(object, "hello", "debug", "test"))
   expect_silent(
-    outpack_log_debug(object, "hello", "trace", "test"))
+    outpack_log_trace(object, "hello", "trace", "test"))
 
   object <- structure(
     list(logger = list(console = TRUE, threshold = "debug")),
@@ -150,7 +150,25 @@ test_that("control logging threshold", {
   expect_message(
     outpack_log_debug(object, "hello", "debug", "test"),
     "[ hello      ]  debug", fixed = TRUE)
+  expect_silent(
+    outpack_log_trace(object, "hello", "trace", "test"))
+
+  object <- structure(
+    list(logger = list(console = TRUE, threshold = "trace")),
+    class = "outpack_root")
   expect_message(
-    outpack_log_debug(object, "hello", "trace", "test"),
+    outpack_log_info(object, "hello", "info", "test"),
+    "[ hello      ]  info", fixed = TRUE)
+  expect_message(
+    outpack_log_debug(object, "hello", "debug", "test"),
+    "[ hello      ]  debug", fixed = TRUE)
+  expect_message(
+    outpack_log_trace(object, "hello", "trace", "test"),
     "[ hello      ]  trace", fixed = TRUE)
+})
+
+
+test_that("reject logging calls with invalid object", {
+  expect_error(outpack_log_info(NULL, "hello", "error", "test"),
+               "Invalid call to outpack_log")
 })


### PR DESCRIPTION
These are making it harder to see newly added holes.

* the scope one is just obsolete code
* the logging one was partly a bug in writing the tests
* the one about a zero length evaluation I could not force triggering this so just removed it!