### PR TITLE
mrc-4327: allow outpack_copy_files to copy from remote locations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.3.4
+Version: 0.3.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/error.R
+++ b/R/error.R
@@ -1,0 +1,4 @@
+not_found_error <- function(message, data) {
+  structure(list(message = message, data = data),
+            class = c("not_found_error", "error", "condition"))
+}

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -4,17 +4,47 @@
 ##' pull files from an outpack root to a directory outside of the
 ##' control of outpack, for example.
 ##'
+##' There are different ways that this might fail (or recover from
+##' failure):
+##'
+##' * if `id` is not known in the metadata store (not known because
+##'   it's not unpacked but also not known to be present in some other
+##'   remote) then this will fail because it's impossible to resolve
+##'   the files. Consider refreshing the metadata with
+##'   [outpack::outpack_location_pull_metadata] to refresh this.
+##' * if the `id` is not unpacked *and* no local copy of the files
+##'   referred to can be found, we error by default (but see the next
+##'   option). However, sometimes the file you refer to might also be
+##'   present because you have downloaded a packet that depended on
+##'   it, or because the content of the file is unchanged because from
+##'   some other packet version you have locally.
+##' * if the `id` is not unpacked, there is no local copy of the file
+##'   and if `allow_remote` is `TRUE` we will try and request the file
+##'   from whatever remote would be selected by
+##'   [outpack::outpack_location_pull_packet] for this packet.
+##'
+##' Note that empty directories might be created on failure.
+##'
 ##' @title Copy files from a packet
 ##'
 ##' @inheritParams outpack_packet_use_dependency
 ##'
 ##' @param dest The directory to copy into
 ##'
+##' @param allow_remote Logical, indicating if we should attempt to
+##'   retrieve the file from any remote location if it cannot be found
+##'   locally. If the file is large, this may take some time depending
+##'   on the speed of the connection. If you use a file store, note
+##'   that this does add the downloaded file into your file store,
+##'   though associated with no packet so that it is subject to
+##'   garbage collection (once we write support for that).
+##'
 ##' @return Nothing, invisibly. Primarily called for its side effect
 ##'   of copying files from a packet into the directory `dest`
 ##'
 ##' @export
-outpack_copy_files <- function(id, files, dest, root = NULL) {
+outpack_copy_files <- function(id, files, dest, allow_remote = FALSE,
+                               root = NULL) {
   root <- outpack_root_open(root, locate = TRUE)
 
   assert_named(files, unique = TRUE)
@@ -23,6 +53,45 @@ outpack_copy_files <- function(id, files, dest, root = NULL) {
   dst <- file.path(dest, names(files))
   validate_packet_has_file(root, id, src)
 
-  file_export(root, id, src, dst)
+  tryCatch(
+    file_export(root, id, src, dst),
+    not_found_error = function(e) {
+      if (allow_remote) {
+        copy_files_from_remote(id, files, dst, root)
+      } else {
+        stop(paste0(
+          "Unable to copy files, as they are not available locally\n",
+          "To fetch from a location, try again with 'allow_remote = TRUE'\n",
+          "Original error:\n", e$message),
+          call. = FALSE)
+      }
+    })
+
   invisible()
+}
+
+
+## We don't want here to necessarily download all of these files; some
+## might be found locally.
+copy_files_from_remote <- function(id, files, dest, root) {
+  location_id <- location_resolve_valid(NULL, root,
+                                        include_local = FALSE,
+                                        allow_no_locations = FALSE)
+  plan <- location_build_pull_plan(id, location_id, root)
+  driver <- location_driver(plan$location_id[match(id, plan$packet)], root)
+
+  meta <- root$metadata(id)
+  hash <- meta$files$hash[match(unname(files), meta$files$path)]
+
+  if (root$config$core$use_file_store) {
+    hash_msg <- hash[!root$files$exists(hash)]
+    location_pull_hash_store(root, driver, hash_msg)
+    root$files$get(hash, dest)
+  } else {
+    src <- lapply(hash, function(h) find_file_by_hash(root, h))
+    is_missing <- vlapply(src, is.null)
+    hash_msg <- hash[is_missing]
+    location_pull_hash_archive(root, driver, hash[is_missing], dest[is_missing])
+    fs::file_copy(list_to_character(src[!is_missing]), dest[!is_missing])
+  }
 }

--- a/R/packet.R
+++ b/R/packet.R
@@ -252,7 +252,7 @@ outpack_packet_use_dependency <- function(packet, query, files) {
   ## this will depend on the query interface.  It's probable that we
   ## might want to record the query here alongside the id, if one was
   ## used?  Or should we allow a query here?
-  outpack_copy_files(id, files, packet$path, packet$root)
+  outpack_copy_files(id, files, packet$path, root = packet$root)
 
   query_str <- deparse_query(query$value$expr,
                              lapply(query$subquery, "[[", "expr"))

--- a/R/store.R
+++ b/R/store.R
@@ -27,8 +27,10 @@ file_store <- R6::R6Class(
     get = function(hash, dst) {
       src <- self$filename(hash)
       if (any(!file.exists(src))) {
-        stop(sprintf("Hash '%s' not found in store",
-                     hash[!file.exists(src)]))
+        missing <- hash[!file.exists(src)]
+        message <- sprintf("Hash not found in store:\n%s",
+                           paste(sprintf("  - %s", missing), collapse = "\n"))
+        stop(not_found_error(message, missing))
       }
       fs::dir_create(dirname(dst))
       fs::file_copy(src, dst)

--- a/R/util.R
+++ b/R/util.R
@@ -167,3 +167,8 @@ as_json <- function(str) {
   assert_scalar_character(str)
   structure(str, class = "json")
 }
+
+
+list_to_character <- function(x) {
+  vcapply(x, identity)
+}

--- a/man/outpack_copy_files.Rd
+++ b/man/outpack_copy_files.Rd
@@ -4,7 +4,7 @@
 \alias{outpack_copy_files}
 \title{Copy files from a packet}
 \usage{
-outpack_copy_files(id, files, dest, root = NULL)
+outpack_copy_files(id, files, dest, allow_remote = FALSE, root = NULL)
 }
 \arguments{
 \item{id}{Optionally, an outpack id via \link{outpack_id}. If
@@ -15,6 +15,14 @@ corresponds to the name within the current packet, while the
 value corresponds to the name within the upstream packet}
 
 \item{dest}{The directory to copy into}
+
+\item{allow_remote}{Logical, indicating if we should attempt to
+retrieve the file from any remote location if it cannot be found
+locally. If the file is large, this may take some time depending
+on the speed of the connection. If you use a file store, note
+that this does add the downloaded file into your file store,
+though associated with no packet so that it is subject to
+garbage collection (once we write support for that).}
 
 \item{root}{The outpack root. Will be searched for from the
 current directory if not given.}
@@ -29,4 +37,27 @@ Copy files from a packet to anywhere. Similar to
 used in an active packet context. You can use this function to
 pull files from an outpack root to a directory outside of the
 control of outpack, for example.
+}
+\details{
+There are different ways that this might fail (or recover from
+failure):
+\itemize{
+\item if \code{id} is not known in the metadata store (not known because
+it's not unpacked but also not known to be present in some other
+remote) then this will fail because it's impossible to resolve
+the files. Consider refreshing the metadata with
+\link{outpack_location_pull_metadata} to refresh this.
+\item if the \code{id} is not unpacked \emph{and} no local copy of the files
+referred to can be found, we error by default (but see the next
+option). However, sometimes the file you refer to might also be
+present because you have downloaded a packet that depended on
+it, or because the content of the file is unchanged because from
+some other packet version you have locally.
+\item if the \code{id} is not unpacked, there is no local copy of the file
+and if \code{allow_remote} is \code{TRUE} we will try and request the file
+from whatever remote would be selected by
+\link{outpack_location_pull_packet} for this packet.
+}
+
+Note that empty directories might be created on failure.
 }

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -260,9 +260,8 @@ test_that("Archive is not added if file store is corrupt", {
   id <- create_random_packet_chain(root, 3)
   hash <- root$metadata(id[["c"]])$files$hash
   fs::file_delete(root$files$filename(hash[[1]]))
-  e <- "Error adding 'path_archive': Hash 'sha256(.*)' not found in store"
   expect_error(outpack_config_set(core.path_archive = "archive", root = root),
-               e)
+               "Error adding 'path_archive': Hash not found in store:")
 
   expect_null(root$config$core$path_archive)
   expect_false(fs::dir_exists(file.path(root$path, "archive")))

--- a/tests/testthat/test-file-store.R
+++ b/tests/testthat/test-file-store.R
@@ -4,7 +4,7 @@ test_that("Can create file store", {
   expect_equal(obj$list(), character(0))
   expect_error(
     obj$get("md5:abcde"),
-    "Hash 'md5:abcde' not found in store")
+    "Hash not found in store:\n  - md5:abcde")
 })
 
 

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -2,9 +2,58 @@ test_that("can copy files from outpack", {
   root <- create_temporary_root(use_file_store = TRUE)
   id <- create_random_packet(root)
   dst <- temp_file()
-  outpack_copy_files(id, c("incoming.rds" = "data.rds"), dst, root)
+  outpack_copy_files(id, c("incoming.rds" = "data.rds"), dst, root = root)
   expect_equal(dir(dst), "incoming.rds")
   expect_identical(
     readRDS(file.path(dst, "incoming.rds")),
     readRDS(file.path(root$path, "archive", "data", id, "data.rds")))
+})
+
+
+test_that("can copy files from location, using store", {
+  here <- create_temporary_root(use_file_store = TRUE)
+  there <- create_temporary_root(use_file_store = TRUE)
+  outpack_location_add("there", "path", list(path = there$path), root = here)
+  id <- create_random_packet(there)
+
+  tmp <- withr::local_tempdir()
+  expect_error(
+    outpack_copy_files(id, c("data.rds" = "data.rds"), tmp, root = here),
+    "id '.+' not found in index")
+  outpack_location_pull_metadata(root = here)
+
+  expect_error(
+    outpack_copy_files(id, c("data.rds" = "data.rds"), tmp, root = here),
+    "Unable to copy files, as they are not available locally")
+
+  outpack_copy_files(id, c("data.rds" = "data.rds"), tmp,
+                     allow_remote = TRUE, root = here)
+  expect_equal(dir(tmp), "data.rds")
+
+  meta <- there$metadata(id)
+  hash <- meta$files$hash[meta$files$path == "data.rds"]
+  expect_equal(hash_file(file.path(tmp, "data.rds"), "sha256"), hash)
+  expect_equal(here$files$list(), hash)
+})
+
+
+test_that("can copy files from location, using archive", {
+  here <- create_temporary_root(use_file_store = FALSE)
+  there <- create_temporary_root(use_file_store = TRUE)
+  outpack_location_add("there", "path", list(path = there$path), root = here)
+  id <- create_random_packet(there)
+
+  tmp <- withr::local_tempdir()
+  outpack_location_pull_metadata(root = here)
+  expect_error(
+    outpack_copy_files(id, c("data.rds" = "data.rds"), tmp, root = here),
+    "Unable to copy files, as they are not available locally")
+
+  outpack_copy_files(id, c("data.rds" = "data.rds"), tmp,
+                     allow_remote = TRUE, root = here)
+  expect_equal(dir(tmp), "data.rds")
+
+  meta <- there$metadata(id)
+  hash <- meta$files$hash[meta$files$path == "data.rds"]
+  expect_equal(hash_file(file.path(tmp, "data.rds"), "sha256"), hash)
 })


### PR DESCRIPTION
This PR allows `outpack_copy_files` to (optionally) use a remote location when copying, which might take longer. This will be used in `mrc-4304` to allow more control over how dependencies are pulled in, but is useful in its own right and sufficiently complex to be considered by itself!