### PR TITLE
Add test that checks behaviour when searching for boolean type parameters

### DIFF
--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -844,3 +844,42 @@ test_that("allow search before query", {
     ids)
   expect_setequal(names(root$a$index()$metadata), ids)
 })
+
+
+test_that("can search for queries using boolean", {
+  root <- create_temporary_root(use_file_store = TRUE)
+  x1 <- create_random_packet(root, "x", list(a = TRUE))
+  x2 <- create_random_packet(root, "x", list(a = FALSE))
+
+  expect_equal(
+    outpack_search(quote(parameter:a == TRUE), root = root),
+    x1)
+  expect_equal(
+    outpack_search(quote(parameter:a == "TRUE"), root = root),
+    x1)
+  expect_equal(
+    outpack_search(quote(parameter:a == 1), root = root),
+    x1)
+  expect_equal(
+    outpack_search(quote(parameter:a == "true"), root = root),
+    character(0))
+  expect_equal(
+    outpack_search(quote(parameter:a == "T"), root = root),
+    character(0))
+
+  expect_equal(
+    outpack_search(quote(parameter:a == FALSE), root = root),
+    x2)
+  expect_equal(
+    outpack_search(quote(parameter:a == "FALSE"), root = root),
+    x2)
+  expect_equal(
+    outpack_search(quote(parameter:a == 0), root = root),
+    x2)
+  expect_equal(
+    outpack_search(quote(parameter:a == "false"), root = root),
+    character(0))
+  expect_equal(
+    outpack_search(quote(parameter:a == "F"), root = root),
+    character(0))
+})

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -850,16 +850,20 @@ test_that("can search for queries using boolean", {
   root <- create_temporary_root(use_file_store = TRUE)
   x1 <- create_random_packet(root, "x", list(a = TRUE))
   x2 <- create_random_packet(root, "x", list(a = FALSE))
+  y1 <- create_random_packet(root, "y", list(a = "TRUE"))
 
   expect_equal(
     outpack_search(quote(parameter:a == TRUE), root = root),
-    x1)
+    c(x1, y1))
   expect_equal(
     outpack_search(quote(parameter:a == "TRUE"), root = root),
-    x1)
+    c(x1, y1))
   expect_equal(
     outpack_search(quote(parameter:a == 1), root = root),
     x1)
+  expect_equal(
+    outpack_search(quote(parameter:a == "1"), root = root),
+    character(0))
   expect_equal(
     outpack_search(quote(parameter:a == "true"), root = root),
     character(0))
@@ -876,6 +880,9 @@ test_that("can search for queries using boolean", {
   expect_equal(
     outpack_search(quote(parameter:a == 0), root = root),
     x2)
+  expect_equal(
+    outpack_search(quote(parameter:a == "0"), root = root),
+    character(0))
   expect_equal(
     outpack_search(quote(parameter:a == "false"), root = root),
     character(0))


### PR DESCRIPTION
This PR just adds a test that checks explicitly the behaviour of querying for boolean types. I couldn't see an existing one and wanted this as a reference for writing the rust impl