### PR TITLE
Replace outpack.server with rust version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,6 +39,13 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - uses: mxschmitt/action-tmate@v3
+        if: runner.os == 'Linux'
+
+      # - name: setup server
+      #   run: |
+      #     cargo install --git https://github.com/mrc-ide/outpack_server --branch main
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,9 +39,6 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: mxschmitt/action-tmate@v3
-        if: runner.os == 'Linux'
-
       # This does take a minute or two to install, and we could cache
       # it but that's not super easy while still allowing easy
       # updating. Once things stabilise we might tag outpack server

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,15 +42,18 @@ jobs:
       - uses: mxschmitt/action-tmate@v3
         if: runner.os == 'Linux'
 
-      # - name: setup server
-      #   run: |
-      #     cargo install --git https://github.com/mrc-ide/outpack_server --branch main
+      # This does take a minute or two to install, and we could cache
+      # it but that's not super easy while still allowing easy
+      # updating. Once things stabilise we might tag outpack server
+      # releases and then we can install and cache against that.
+      - name: setup server
+        run: |
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch main
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::rcmdcheck
-            github::reside-ic/porcelain
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -25,8 +25,11 @@ jobs:
         with:
           extra-packages: |
             any::covr
-            github::reside-ic/porcelain
           needs: coverage
+
+      - name: setup server
+        run: |
+          cargo install --git https://github.com/mrc-ide/outpack_server --branch main
 
       - name: Test coverage
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Suggests:
     jsonvalidate (>= 1.4.0),
     knitr,
     mockery,
+    processx,
     remotes,
     rmarkdown,
     testthat (>= 3.0.0),

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ To install `outpack`:
 remotes::install_github("mrc-ide/outpack", upgrade = FALSE)
 ```
 
+## Testing
+
+To run all tests, you need to have [`outpack_server`])(https://github.com/mrc-ide/outpack_server) available on your system path. One way to achieve this is to run
+
+```
+cargo install --git https://github.com/mrc-ide/outpack_server
+```
+
 ## License
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -1,33 +1,10 @@
-## A bit of sleight of hand is needed here to avoid a bit of a
-## circular dependency. We'll relax this later once we get a non-R
-## version of this sorted out.
-##
-## The getNamespace(ns)$fn constructions are equivalent to ns::fn but
-## will slide under R CMD check without warnings that would break the
-## build.
-##
-## For an eventual CRAN release we'l need some other way of doing this
-## though.
-install_deps <- function() {
-  if (!requireNamespace("outpack.server", quietly = TRUE)) {
-    message("Installing additional requirements")
-    getNamespace("remotes")$install_github("mrc-ide/outpack.server@mrc-3112",
-                                           upgrade = FALSE)
+outpack_server <- function(path) {
+  outpack_server <- Sys.which("outpack_server")
+  if (!nzchar(outpack_server)) {
+    testthat::skip("outpack_server not installed")
   }
-}
-
-
-outpack_server <- function(path, validate = NULL, log_level = "info",
-                           start = TRUE) {
-  testthat::skip_on_os("windows") # does not work on gha due to install issues
-  install_deps()
-  create <- function(path, validate, log_level) {
-    getNamespace("outpack.server")$api(path, validate, log_level)
-  }
-  args <- list(path = path, validate = validate, log_level = log_level)
-  bg <- getNamespace("porcelain")$porcelain_background$new(create, args)
-  if (start) {
-    bg$start()
-  }
-  bg
+  args <- c("--root", path)
+  px <- processx::process$new(outpack_server, args)
+  withr::defer_parent(px$kill())
+  px
 }

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -12,7 +12,7 @@ outpack_server <- function(path, timeout = 10) {
   while (!success && px$is_alive() && Sys.time() < t_end) {
     message("testing...")
     result <- tryCatch(httr::GET("http://localhost:8000"), error = identity)
-    success <- !inherits(res, "error")
+    success <- !inherits(result, "error")
   }
   if (!success) {
     stop("Failed to bring up server!")

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -1,4 +1,4 @@
-outpack_server <- function(path) {
+outpack_server <- function(path, timeout = 10) {
   outpack_server <- Sys.which("outpack_server")
   if (!nzchar(outpack_server)) {
     testthat::skip("outpack_server not installed")
@@ -6,5 +6,16 @@ outpack_server <- function(path) {
   args <- c("--root", path)
   px <- processx::process$new(outpack_server, args)
   withr::defer_parent(px$kill())
+
+  t_end <- Sys.time() + timeout
+  success <- FALSE
+  while (!success && px$is_alive() && Sys.time() < t_end) {
+    message("testing...")
+    result <- tryCatch(httr::GET("http://localhost:8000"), error = identity)
+    success <- !inherits(res, "error")
+  }
+  if (!success) {
+    stop("Failed to bring up server!")
+  }
   px
 }

--- a/tests/testthat/test-zzz-location-http.R
+++ b/tests/testthat/test-zzz-location-http.R
@@ -2,8 +2,8 @@ describe("server integration tests", {
   root <- create_temporary_root(path_archive = "archive", use_file_store = TRUE)
   path <- root$path
   server <- outpack_server(path)
+  url <- "http://localhost:8000"
 
-  url <- server$url("")
   client_http <- outpack_location_http$new(url)
   client_path <- outpack_location_path$new(path)
 
@@ -20,7 +20,7 @@ describe("server integration tests", {
   })
 
   it("returns compatible metadata", {
-    expect_identical(client_http$metadata(ids),
+    expect_identical(trimws(client_http$metadata(ids)),
                      client_path$metadata(ids))
   })
 
@@ -58,7 +58,7 @@ describe("http location integration tests", {
   root <- create_temporary_root(path_archive = "archive", use_file_store = TRUE)
   path <- root$path
   server <- outpack_server(path)
-  url <- server$url("")
+  url <- "http://localhost:8000"
 
   ids <- vcapply(1:3, function(i) create_random_packet(path))
 


### PR DESCRIPTION
This PR replaces the outpack.server http server with the rust one. Only one test needed updating, and that's a difference in trailing whitespace, which is not a big deal.