### PR TITLE
mrc-4353: only forward packets we have unpacked

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack
 Title: Package Output
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/location.R
+++ b/R/location.R
@@ -546,7 +546,7 @@ location_build_push_plan <- function(packet_id, location_id, root) {
   driver <- location_driver(location_id, root)
 
   packet_id <- sort(find_all_dependencies(packet_id, root$index()$metadata))
-  packet_id_msg <- driver$list_unknown_packets(packet_id, unpacked = TRUE)
+  packet_id_msg <- driver$list_unknown_packets(packet_id)
 
   if (length(packet_id_msg) == 0) {
     files_msg <- character(0)

--- a/R/location_path.R
+++ b/R/location_path.R
@@ -52,11 +52,8 @@ outpack_location_path <- R6::R6Class(
       dest
     },
 
-    list_unknown_packets = function(ids, unpacked) {
-      if (!unpacked) {
-        stop("Eliminate this option!")
-      }
-      root_list_unknown_packets(ids, unpacked = TRUE, root = private$root)
+    list_unknown_packets = function(ids) {
+      root_list_unknown_packets(ids, root = private$root)
     },
 
     list_unknown_files = function(hashes) {
@@ -88,7 +85,7 @@ location_path_import_metadata <- function(str, hash, root) {
       sprintf("Can't import metadata for '%s', as files missing:\n%s",
               id, paste(sprintf("  - %s", unknown_files), collapse = "\n")))
   }
-  unknown_packets <- root_list_unknown_packets(meta$depends$packet, TRUE, root)
+  unknown_packets <- root_list_unknown_packets(meta$depends$packet, root)
   if (length(unknown_packets) > 0) {
     stop(sprintf(
       "Can't import metadata for '%s', as dependencies missing:\n%s",

--- a/R/root.R
+++ b/R/root.R
@@ -427,12 +427,8 @@ validate_packet_has_file <- function(root, id, path) {
 }
 
 
-root_list_unknown_packets <- function(ids, unpacked, root) {
-  if (unpacked) {
-    setdiff(ids, root$index()$unpacked)
-  } else {
-    setdiff(ids, names(root$index()$metadata))
-  }
+root_list_unknown_packets <- function(ids, root) {
+  setdiff(ids, root$index()$unpacked)
 }
 
 

--- a/tests/testthat/test-location.R
+++ b/tests/testthat/test-location.R
@@ -159,6 +159,7 @@ test_that("Removing a location orphans packets only from that location", {
   id1 <- create_random_packet(root$c)
   id2 <- create_random_packet(root$b)
   outpack_location_pull_metadata(root = root$b)
+  outpack_location_pull_packet(id1, root = root$b)
   outpack_location_pull_metadata(root = root$a)
 
   # id1 should now be found in both b and c
@@ -326,7 +327,9 @@ test_that("Can pull metadata through chain of locations", {
   ## Create a packet and make sure it's in both b and c
   id1 <- create_random_packet(root$a)
   outpack_location_pull_metadata(root = root$b)
+  outpack_location_pull_packet(id1, root = root$b)
   outpack_location_pull_metadata(root = root$c)
+  outpack_location_pull_packet(id1, root = root$c)
 
   ## And another in just 'c'
   id2 <- create_random_packet(root$c)
@@ -610,12 +613,16 @@ test_that("Can filter locations", {
   ids_a <- vcapply(1:3, function(i) create_random_packet(root$a$path))
   outpack_location_add("a", "path", list(path = root$a$path), root = root$b)
   outpack_location_pull_metadata(root = root$b)
+  outpack_location_pull_packet(ids_a, root = root$b)
+
   ids_b <- c(ids_a,
              vcapply(1:3, function(i) create_random_packet(root$b$path)))
   ids_c <- vcapply(1:3, function(i) create_random_packet(root$c$path))
   outpack_location_add("a", "path", list(path = root$a$path), root = root$d)
   outpack_location_add("c", "path", list(path = root$c$path), root = root$d)
   outpack_location_pull_metadata(root = root$d)
+  outpack_location_pull_packet(ids_a, root = root$d)
+  outpack_location_pull_packet(ids_c, root = root$d)
   ids_d <- c(ids_c,
              vcapply(1:3, function(i) create_random_packet(root$d$path)))
 

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -144,26 +144,24 @@ test_that("Can work out what packets are missing", {
   outpack_location_pull_metadata(root = root$b)
 
   ## Nothing missing in this case:
-  expect_equal(root_list_unknown_packets(ids, TRUE, root$a),
+  expect_equal(root_list_unknown_packets(ids, root$a),
                character())
-  expect_equal(root_list_unknown_packets(ids[[1]], TRUE, root$a),
+  expect_equal(root_list_unknown_packets(ids[[1]], root$a),
                character())
-  expect_equal(root_list_unknown_packets(character(), TRUE, root$a),
+  expect_equal(root_list_unknown_packets(character(), root$a),
                character())
 
   ids_fake <- replicate(4, outpack_id())
-  expect_equal(root_list_unknown_packets(ids_fake, TRUE, root$a),
+  expect_equal(root_list_unknown_packets(ids_fake, root$a),
                ids_fake)
-  expect_equal(root_list_unknown_packets(rev(ids_fake), TRUE, root$a),
+  expect_equal(root_list_unknown_packets(rev(ids_fake), root$a),
                rev(ids_fake))
 
   ids_all <- sample(c(unname(ids), ids_fake))
-  expect_equal(root_list_unknown_packets(ids_all, TRUE, root$a),
+  expect_equal(root_list_unknown_packets(ids_all, root$a),
                setdiff(ids_all, ids))
-  expect_equal(root_list_unknown_packets(ids_all, TRUE, root$b),
+  expect_equal(root_list_unknown_packets(ids_all, root$b),
                ids_all)
-  expect_equal(root_list_unknown_packets(ids_all, FALSE, root$b),
-               setdiff(ids_all, ids))
 })
 
 


### PR DESCRIPTION
Fallout from #76, as flagged there - this PR updates the path location to only advertise packets it fully knows about. Later we'll add support for proxying other locations (and at the same time excluding some of these from the requirement of having a full tree).